### PR TITLE
Enable bulid-scan-link capture

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -104,9 +104,11 @@ if (develocityInjectionEnabled) {
     enableDevelocityInjection()
 }
 
-def buildScanCaptureEnabled = this.metaClass.respondsTo(this, 'captureBuildScanLink', String)
+// To enable build-scan capture, a `captureBuildScanLink(String)` method must be added to `BuildScanCollector`.
+def buildScanCollector = new BuildScanCollector()
+def buildScanCaptureEnabled = buildScanCollector.metaClass.respondsTo(buildScanCollector, 'captureBuildScanLink', String)
 if (buildScanCaptureEnabled) {
-    enableBuildScanLinkCapture()
+    enableBuildScanLinkCapture(buildScanCollector)
 }
 
 void enableDevelocityInjection() {
@@ -375,7 +377,7 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     !isAtLeast(versionUnderTest, referenceVersion)
 }
 
-void enableBuildScanLinkCapture() {
+void enableBuildScanLinkCapture(BuildScanCollector collector) {
     def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
     def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
 
@@ -385,28 +387,30 @@ void enableBuildScanLinkCapture() {
             pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                 // Only execute if develocity plugin isn't applied.
                 if (gradle.rootProject.extensions.findByName("develocity")) return
-                buildScanPublishedAction(buildScan)
+                buildScanPublishedAction(buildScan, collector)
             }
 
             pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                buildScanPublishedAction(develocity.buildScan)
+                buildScanPublishedAction(develocity.buildScan, collector)
             }
         }
     } else {
         gradle.settingsEvaluated { settings ->
             eachDevelocitySettingsExtension(settings) { ext ->
-                buildScanPublishedAction(ext.buildScan)
+                buildScanPublishedAction(ext.buildScan, collector)
             }
         }
     }
 }
 
-// Action will only be called if a `captureBuildScanLink` method is present in this file.
-// Add `void captureBuildScanLink(String) {}` to respond to buildScanPublished events
-void buildScanPublishedAction(def buildScanExtension) {
+// Action will only be called if a `BuildScanCollector.captureBuildScanLink` method is present.
+// Add `void captureBuildScanLink(String) {}` to the `BuildScanCollector` class to respond to buildScanPublished events
+static buildScanPublishedAction(def buildScanExtension, BuildScanCollector collector) {
     if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'buildScanPublished', Action)) {
         buildScanExtension.buildScanPublished { scan ->
-            captureBuildScanLink(scan.buildScanUri.toString())
+            collector.captureBuildScanLink(scan.buildScanUri.toString())
         }
     }
 }
+
+class BuildScanCollector {}

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -104,6 +104,11 @@ if (develocityInjectionEnabled) {
     enableDevelocityInjection()
 }
 
+def buildScanCaptureEnabled = this.metaClass.respondsTo(this, 'captureBuildScanLink', String)
+if (buildScanCaptureEnabled) {
+    enableBuildScanLinkCapture()
+}
+
 void enableDevelocityInjection() {
     def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
     def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
@@ -368,4 +373,40 @@ static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     !isAtLeast(versionUnderTest, referenceVersion)
+}
+
+void enableBuildScanLinkCapture() {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                // Only execute if develocity plugin isn't applied.
+                if (gradle.rootProject.extensions.findByName("develocity")) return
+                buildScanPublishedAction(buildScan)
+            }
+
+            pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                buildScanPublishedAction(develocity.buildScan)
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            eachDevelocitySettingsExtension(settings) { ext ->
+                buildScanPublishedAction(ext.buildScan)
+            }
+        }
+    }
+}
+
+// Action will only be called if a `captureBuildScanLink` method is present in this file.
+// Add `void captureBuildScanLink(String) {}` to respond to buildScanPublished events
+void buildScanPublishedAction(def buildScanExtension) {
+    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'buildScanPublished', Action)) {
+        buildScanExtension.buildScanPublished { scan ->
+            captureBuildScanLink(scan.buildScanUri.toString())
+        }
+    }
 }

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -14,8 +14,8 @@ initscript {
         return
     }
 
-    def ENV_VAR_PREFIX = ''
     def getInputParam = { String name ->
+        def ENV_VAR_PREFIX = ''
         def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
@@ -26,9 +26,9 @@ initscript {
         return
     }
 
-    // finish early if injection is disabled
-    def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-    if (gradleInjectionEnabled != "true") {
+    // plugin loading is only required for Develocity injection
+    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+    if (!develocityInjectionEnabled) {
         return
     }
 
@@ -81,28 +81,15 @@ initscript {
     }
 }
 
-def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
-
-def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
-def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-
-def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
-
-def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
-def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+static getInputParam(String name) {
+    def ENV_VAR_PREFIX = ''
+    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
+    return System.getProperty(name) ?: System.getenv(envVarName)
+}
 
 def isTopLevelBuild = !gradle.parent
 if (!isTopLevelBuild) {
     return
-}
-
-def ENV_VAR_PREFIX = ''
-def getInputParam = { String name ->
-    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
 def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
@@ -112,205 +99,219 @@ if (requestedInitScriptName != initScriptName) {
     return
 }
 
-// finish early if injection is disabled
-def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
-if (gradleInjectionEnabled != "true") {
-    return
+def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+if (develocityInjectionEnabled) {
+    enableDevelocityInjection()
 }
 
-def develocityUrl = getInputParam('develocity.url')
-def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
-def develocityPluginVersion = getInputParam('develocity.plugin.version')
-def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+void enableDevelocityInjection() {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
-def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
-def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+    def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+    def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
 
-def dvOrGe = { def dvValue, def geValue ->
-    if (shouldApplyDevelocityPlugin) {
-        return dvValue instanceof Closure<?> ? dvValue() : dvValue
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+    def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+
+    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+    def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+    def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
+    def develocityUrl = getInputParam('develocity.url')
+    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+    def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
+    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+    def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+    def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+    def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+
+    def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+    def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+    def shouldApplyDevelocityPlugin = atLeastGradle5 && develocityPluginVersion && isAtLeast(develocityPluginVersion, '3.17')
+
+    def dvOrGe = { def dvValue, def geValue ->
+        if (shouldApplyDevelocityPlugin) {
+            return dvValue instanceof Closure<?> ? dvValue() : dvValue
+        }
+        return geValue instanceof Closure<?> ? geValue() : geValue
     }
-    return geValue instanceof Closure<?> ? geValue() : geValue
-}
 
-// finish early if configuration parameters passed in via system properties are not valid/supported
-if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-    logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
-    return
-}
+    // finish early if configuration parameters passed in via system properties are not valid/supported
+    if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+        logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+        return
+    }
 
-// Conditionally apply and configure the Develocity plugin
-if (GradleVersion.current() < GradleVersion.version('6.0')) {
-    rootProject {
-        buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
-            def resolutionResult = incoming.resolutionResult
+    // Conditionally apply and configure the Develocity plugin
+    if (GradleVersion.current() < GradleVersion.version('6.0')) {
+        rootProject {
+            buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+                def resolutionResult = incoming.resolutionResult
 
-            if (develocityPluginVersion) {
-                def scanPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
-                }
-                if (!scanPluginComponent) {
-                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                    logger.lifecycle("Applying $pluginClass via init script")
-                    applyPluginExternally(pluginManager, pluginClass)
-                    def rootExtension = dvOrGe(
-                        { develocity },
-                        { buildScan }
-                    )
-                    def buildScanExtension = dvOrGe(
-                        { rootExtension.buildScan },
-                        { rootExtension }
-                    )
-                    if (develocityUrl) {
-                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        rootExtension.server = develocityUrl
-                        rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                if (develocityPluginVersion) {
+                    def scanPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
                     }
-                    if (!shouldApplyDevelocityPlugin) {
-                        // Develocity plugin publishes scans by default
-                        buildScanExtension.publishAlways()
-                    }
-                    // uploadInBackground not available for build-scan-plugin 1.16
-                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
-                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                    if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        if (isAtLeast(develocityPluginVersion, '3.17')) {
-                            buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
-                        } else if (isAtLeast(develocityPluginVersion, '3.7')) {
-                            buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
-                        } else {
-                            buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                    if (!scanPluginComponent) {
+                        def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                        logger.lifecycle("Applying $pluginClass via init script")
+                        applyPluginExternally(pluginManager, pluginClass)
+                        def rootExtension = dvOrGe(
+                            { develocity },
+                            { buildScan }
+                        )
+                        def buildScanExtension = dvOrGe(
+                            { rootExtension.buildScan },
+                            { rootExtension }
+                        )
+                        if (develocityUrl) {
+                            logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            rootExtension.server = develocityUrl
+                            rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                        if (!shouldApplyDevelocityPlugin) {
+                            // Develocity plugin publishes scans by default
+                            buildScanExtension.publishAlways()
+                        }
+                        // uploadInBackground not available for build-scan-plugin 1.16
+                        if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                        buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                        if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            if (isAtLeast(develocityPluginVersion, '3.17')) {
+                                buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
+                            } else if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
+                            } else {
+                                buildScanExtension.captureTaskInputFiles = develocityCaptureFileFingerprints
+                            }
                         }
                     }
+
+                    if (develocityUrl && develocityEnforceUrl) {
+                        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                    }
+
+                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                        // Only execute if develocity plugin isn't applied.
+                        if (gradle.rootProject.extensions.findByName("develocity")) return
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                buildScan.server = develocityUrl
+                                buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+
+                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                develocity.server = develocityUrl
+                                develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
+                    }
+                }
+
+                if (ccudPluginVersion && atLeastGradle4) {
+                    def ccudPluginComponent = resolutionResult.allComponents.find {
+                        it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+                    }
+                    if (!ccudPluginComponent) {
+                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                        pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+                    }
+                }
+            }
+        }
+    } else {
+        gradle.settingsEvaluated { settings ->
+            if (develocityPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                    logger.lifecycle("Applying $pluginClass via init script")
+                    applyPluginExternally(settings.pluginManager, pluginClass)
+                    if (develocityUrl) {
+                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        eachDevelocitySettingsExtension(settings) { ext ->
+                            ext.server = develocityUrl
+                            ext.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
+
+                    eachDevelocitySettingsExtension(settings) { ext ->
+                        ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                        ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
+                    }
+
+                    eachDevelocitySettingsExtension(settings,
+                        { develocity ->
+                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                        },
+                        { gradleEnterprise ->
+                            gradleEnterprise.buildScan.publishAlways()
+                            if (isAtLeast(develocityPluginVersion, '2.1')) {
+                                logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                    gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                                } else {
+                                    gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
+                                }
+                            }
+                        }
+                    )
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
                     logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                 }
 
-                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                    // Only execute if develocity plugin isn't applied.
-                    if (gradle.rootProject.extensions.findByName("develocity")) return
-                    afterEvaluate {
-                        if (develocityUrl && develocityEnforceUrl) {
-                            buildScan.server = develocityUrl
-                            buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                        buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                    }
-                }
-
-                pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                    afterEvaluate {
+                eachDevelocitySettingsExtension(settings,
+                    { develocity ->
                         if (develocityUrl && develocityEnforceUrl) {
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
-                    }
 
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                    }
-                }
-            }
-
-            if (ccudPluginVersion && atLeastGradle4) {
-                def ccudPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
-                }
-                if (!ccudPluginComponent) {
-                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                    pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
-                }
-            }
-        }
-    }
-} else {
-    gradle.settingsEvaluated { settings ->
-        if (develocityPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                logger.lifecycle("Applying $pluginClass via init script")
-                applyPluginExternally(settings.pluginManager, pluginClass)
-                if (develocityUrl) {
-                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                    eachDevelocitySettingsExtension(settings) { ext ->
-                        ext.server = develocityUrl
-                        ext.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-                }
-
-                eachDevelocitySettingsExtension(settings) { ext ->
-                    ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
-                }
-
-                eachDevelocitySettingsExtension(settings,
-                    { develocity ->
-                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                        develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                        }
                     },
                     { gradleEnterprise ->
-                        gradleEnterprise.buildScan.publishAlways()
-                        if (isAtLeast(develocityPluginVersion, '2.1')) {
-                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                            if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                            } else {
-                                gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                            }
+                        if (develocityUrl && develocityEnforceUrl) {
+                            gradleEnterprise.server = develocityUrl
+                            gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                            gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
                         }
                     }
                 )
             }
 
-            if (develocityUrl && develocityEnforceUrl) {
-                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-            }
-
-            eachDevelocitySettingsExtension(settings,
-                { develocity ->
-                    if (develocityUrl && develocityEnforceUrl) {
-                        develocity.server = develocityUrl
-                        develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                    }
-                },
-                { gradleEnterprise ->
-                    if (develocityUrl && develocityEnforceUrl) {
-                        gradleEnterprise.server = develocityUrl
-                        gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                    }
-
-                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                        gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                        gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                    }
+            if (ccudPluginVersion) {
+                if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                    settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                 }
-            )
-        }
-
-        if (ccudPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
             }
         }
     }

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -46,12 +46,12 @@ abstract class BaseInitScriptTest extends Specification {
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
     static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'
     static final String ROOT_PROJECT_NAME = 'test-init-script'
+    static final String INIT_SCRIPT_SOURCE = 'src/main/resources/develocity-injection.init.gradle'
     boolean failScanUpload = false
 
     File settingsFile
     File buildFile
-
-    def initScript = 'src/main/resources/develocity-injection.init.gradle'
+    File initScriptFile
 
     boolean allowDevelocityDeprecationWarning = false
 
@@ -115,6 +115,9 @@ abstract class BaseInitScriptTest extends Specification {
     }
 
     def setup() {
+        initScriptFile = new File(testProjectDir, 'develocity-injection.init.gradle')
+        initScriptFile.text = new File(INIT_SCRIPT_SOURCE).text
+
         settingsFile = new File(testProjectDir, 'settings.gradle')
         buildFile = new File(testProjectDir, 'build.gradle')
 
@@ -188,7 +191,7 @@ abstract class BaseInitScriptTest extends Specification {
     }
 
     GradleRunner createRunner(List<String> args, GradleVersion gradleVersion = GradleVersion.current(), Map<String, String> envVars = [:]) {
-        args << '-I' << new File(initScript).absolutePath
+        args << '-I' << initScriptFile.absolutePath
 
         def runner = ((DefaultGradleRunner) GradleRunner.create())
             .withGradleVersion(gradleVersion.version)
@@ -277,7 +280,5 @@ abstract class BaseInitScriptTest extends Specification {
         String toString() {
             return "Gradle " + gradleVersion.version
         }
-
     }
-
 }

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -1,0 +1,84 @@
+package com.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+class TestBuildScanCapture extends BaseInitScriptTest {
+
+    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    def "does not capture build scan url when init-script not enabled"() {
+        given:
+        captureBuildScanLinks()
+
+        when:
+        def result = run(['help'], testGradleVersion.gradleVersion, [:])
+
+        then:
+        buildScanUrlIsNotCaptured(result)
+
+        where:
+        testGradleVersion << ALL_VERSIONS
+    }
+
+    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    def "can capture build scan url with develocity injection"() {
+        given:
+        captureBuildScanLinks()
+
+        when:
+        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, DEVELOCITY_PLUGIN_VERSION)
+        def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
+
+        then:
+        buildScanUrlIsCaptured(result)
+
+        where:
+        testGradleVersion << ALL_VERSIONS
+    }
+
+    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    def "can capture build scan url without develocity injection"() {
+        given:
+        captureBuildScanLinks()
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
+
+        when:
+        def config = new MinimalTestConfig()
+        def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
+
+        then:
+        buildScanUrlIsCaptured(result)
+
+        where:
+        testGradleVersion << ALL_VERSIONS
+    }
+
+    void buildScanUrlIsCaptured(BuildResult result) {
+        def message = "BUILD_SCAN_URL='${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID'"
+        assert result.output.contains(message)
+        assert 1 == result.output.count(message)
+    }
+
+    void buildScanUrlIsNotCaptured(BuildResult result) {
+        def message = "BUILD_SCAN_URL='${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID'"
+        assert !result.output.contains(message)
+    }
+
+    void captureBuildScanLinks() {
+        initScriptFile << '''
+            def captureBuildScanLink(String buildScanUrl) {
+                println "BUILD_SCAN_URL='${buildScanUrl}'"
+            }
+        '''
+    }
+
+    static class MinimalTestConfig {
+        Map<String, String> getEnvVars() {
+            Map<String, String> envVars = [
+                DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity-injection.init.gradle",
+            ]
+            return envVars
+        }
+    }
+
+}

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -407,16 +407,20 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert 1 == result.output.count(enforceUrl)
     }
 
-    private BuildResult run(TestGradleVersion testGradleVersion, TestConfig config, List<String> args = ["help"]) {
+    private BuildResult run(TestGradleVersion testGradleVersion, DvInjectionTestConfig config, List<String> args = ["help"]) {
         return run(args, testGradleVersion.gradleVersion, config.envVars)
     }
 
-    private TestConfig testConfig(String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
-        new TestConfig(develocityPluginVersion)
+    DvInjectionTestConfig testConfig(String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
+        createTestConfig(mockScansServer.address, develocityPluginVersion)
     }
 
-    class TestConfig {
-        String serverUrl = mockScansServer.address.toString()
+    static DvInjectionTestConfig createTestConfig(URI serverAddress, String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
+        new DvInjectionTestConfig(serverAddress, develocityPluginVersion.toString())
+    }
+
+    static class DvInjectionTestConfig {
+        String serverUrl
         boolean enforceUrl = false
         String ccudPluginVersion = null
         String pluginRepositoryUrl = null
@@ -425,38 +429,39 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         boolean captureFileFingerprints = false
         String develocityPluginVersion
 
-        TestConfig(String develocityPluginVersion) {
+        DvInjectionTestConfig(URI serverAddress, String develocityPluginVersion) {
+            this.serverUrl = serverAddress.toString()
             this.develocityPluginVersion = develocityPluginVersion
         }
 
-        TestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
+        DvInjectionTestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
             ccudPluginVersion = version
             return this
         }
 
-        TestConfig withServer(URI url, boolean enforceUrl = false) {
+        DvInjectionTestConfig withServer(URI url, boolean enforceUrl = false) {
             serverUrl = url.toASCIIString()
             this.enforceUrl = enforceUrl
             return this
         }
 
-        TestConfig withPluginRepository(URI pluginRepositoryUrl) {
+        DvInjectionTestConfig withPluginRepository(URI pluginRepositoryUrl) {
             this.pluginRepositoryUrl = pluginRepositoryUrl
             return this
         }
 
-        TestConfig withCaptureFileFingerprints() {
+        DvInjectionTestConfig withCaptureFileFingerprints() {
             this.captureFileFingerprints = true
             return this
         }
 
-        TestConfig withPluginRepositoryCredentials(String pluginRepoUsername, String pluginRepoPassword) {
+        DvInjectionTestConfig withPluginRepositoryCredentials(String pluginRepoUsername, String pluginRepoPassword) {
             this.pluginRepositoryUsername = pluginRepoUsername
             this.pluginRepositoryPassword = pluginRepoPassword
             return this
         }
 
-        def getEnvVars() {
+        Map<String, String> getEnvVars() {
             Map<String, String> envVars = [
                 DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity-injection.init.gradle",
                 DEVELOCITY_INJECTION_ENABLED              : "true",


### PR DESCRIPTION
If a consumer adds a `captureBuildScanLink` method implementation to the init-script,
this method will be notified with links for all build scans published by the build.