### PR TITLE
Use a genuine bot account for most GitHub operations

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -15,6 +15,15 @@ jobs:
   update-reference:
     runs-on: ubuntu-latest
     steps:
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
@@ -32,7 +41,10 @@ jobs:
       - name: Commit & push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: '[bot] Update develocity-injection reference script as ${{ inputs.version }}'
+          commit_author: bot-githubaction <bot-githubaction@gradle.com>
+          commit_user_name: bot-githubaction
+          commit_user_email: bot-githubaction@gradle.com
+          commit_message: '[bot] Promote init-script as ${{ inputs.version }}'
           tagging_message: '${{ inputs.version }}'
 
   update-gradle-actions:

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -47,6 +47,9 @@ jobs:
           commit_message: '[bot] Promote init-script as ${{ inputs.version }}'
           tagging_message: '${{ inputs.version }}'
 
+  #########################################
+  # CI plugins hosted in the `gradle` org #
+  #########################################
   update-gradle-actions:
     needs: [update-reference]
     uses: ./.github/workflows/gradle-send-update-pr.yml
@@ -54,8 +57,7 @@ jobs:
       version: ${{ inputs.version }}
       repository: 'gradle/actions'
       script-location: 'sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle'
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    secrets: inherit
 
   update-develocity-gitlab-templates:
     needs: [update-reference]
@@ -65,18 +67,7 @@ jobs:
       repository: 'gradle/develocity-gitlab-templates'
       script-location: 'src/gradle/init-scripts/develocity-injection.init.gradle'
       post-process: './build.sh'
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  update-jenkins-gradle-plugin:
-    needs: [update-reference]
-    uses: ./.github/workflows/gradle-send-update-pr.yml
-    with:
-      version: ${{ inputs.version }}
-      repository: 'jenkinsci/gradle-plugin'
-      script-location: 'src/main/resources/hudson/plugins/gradle/injection/init-script.gradle'
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    secrets: inherit
 
   update-develocity-bamboo-plugin:
     needs: [update-reference]
@@ -87,8 +78,22 @@ jobs:
       script-location: 'src/main/resources/develocity/gradle/develocity-init-script.gradle'
       post-process: |
         sed -i "s/def ENV_VAR_PREFIX = ''/def ENV_VAR_PREFIX = 'bamboo_'/" src/main/resources/develocity/gradle/develocity-init-script.gradle
+    secrets: inherit
+
+  #################################################
+  # CI plugins hosted outside of the `gradle` org #
+  #################################################
+  update-jenkins-gradle-plugin:
+    needs: [update-reference]
+    uses: ./.github/workflows/gradle-send-update-pr.yml
+    with:
+      version: ${{ inputs.version }}
+      repository: 'jenkinsci/gradle-plugin'
+      script-location: 'src/main/resources/hudson/plugins/gradle/injection/init-script.gradle'
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_BOT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_BOT_PGP_PRIVATE_KEY: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
+      GH_BOT_PGP_PASSPHRASE: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}
 
   update-develocity-teamcity-plugin:
     needs: [update-reference]
@@ -98,4 +103,6 @@ jobs:
       repository: 'bigdaz/teamcity-build-scan-plugin'
       script-location: 'agent/src/main/resources/build-scan-init.gradle'
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_BOT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_BOT_PGP_PRIVATE_KEY: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
+      GH_BOT_PGP_PASSPHRASE: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}

--- a/.github/workflows/gradle-send-update-pr.yml
+++ b/.github/workflows/gradle-send-update-pr.yml
@@ -16,22 +16,36 @@ on:
         type: string
         required: false
     secrets:
-      GH_TOKEN:
+      GH_BOT_GITHUB_TOKEN:
         required: true
-      
+      GH_BOT_PGP_PRIVATE_KEY:
+        required: true
+      GH_BOT_PGP_PASSPHRASE:
+        required: true
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+
       - uses: actions/checkout@v4
         with:
-            ref: main # Include the changes commmited in the previous job
+          ref: dd/bot-user # Include the changes commmited in the previous job
+          token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
           path: ${{ inputs.repository }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}
 
       - name: Copy reference script
         run: cp reference/develocity-injection.init.gradle ${{ inputs.repository }}/${{ inputs.script-location }}
@@ -46,15 +60,17 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
+          path: ${{ inputs.repository }}
+          committer:  Bot Githubaction <bot-githubaction@gradle.com>
+          author: Bot Githubaction <bot-githubaction@gradle.com>
+          token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}
           branch: bot/develocity-injection-init-script-update
           delete-branch: true
-          path: ${{ inputs.repository }}
-          token: ${{ secrets.GH_TOKEN }}
           title: 'Update develocity-injection init script to ${{ inputs.version }}'
           body: |
             Updates the develocity-injection init script to the latest reference script content
             from https://github.com/gradle/develocity-ci-injection.
-          commit-message: |
+          commit-message: | 
             Update develocity-injection init script to ${{ inputs.version }}
 
             Updates the develocity-injection init script to the latest reference script content

--- a/.github/workflows/gradle-send-update-pr.yml
+++ b/.github/workflows/gradle-send-update-pr.yml
@@ -48,10 +48,17 @@ jobs:
         with:
           branch: bot/develocity-injection-init-script-update
           delete-branch: true
-          commit-message: 'Update develocity-injection init script to ${{ inputs.version }}'
-          title: 'Update develocity-injection init script'
           path: ${{ inputs.repository }}
           token: ${{ secrets.GH_TOKEN }}
+          title: 'Update develocity-injection init script to ${{ inputs.version }}'
+          body: |
+            Updates the develocity-injection init script to the latest reference script content
+            from https://github.com/gradle/develocity-ci-injection.
+          commit-message: |
+            Update develocity-injection init script to ${{ inputs.version }}
+
+            Updates the develocity-injection init script to the latest reference script content
+            from https://github.com/gradle/develocity-ci-injection.
 
       - name: Include link to PR in Job Summary
         if: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
- Commit changes to reference script as bot user
- Improve title and body of generated PR
- Commit and sign PRs with bot-githubaction account