### PR TITLE
Develocity URL is enforced even if Develocity plugin is not applied by the init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The following Develocity CI integrations leverage the Gradle init-script from th
 - Jenkins: [Jenkins Gradle Plugin](https://github.com/jenkinsci/gradle-plugin)
 - GitLab: [Develocity Gitlab Templates](https://github.com/gradle/develocity-gitlab-templates)
 - TeamCity: [TeamCity Build Scan Plugin](https://github.com/etiennestuder/teamcity-build-scan-plugin)
+
+The following Develocity tooling also leverages this init-script.
+
+- [Develocity Build Validation Scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     `jvm-test-suite`
 }
 
+group = "com.gradle"
+
 repositories {
     mavenCentral()
 }
@@ -39,4 +41,12 @@ tasks.register<Copy>("promote") {
         }
     }
     into("reference")
+}
+
+// Exposes the init script as a resolvable artifact when this project is used as
+// an included build.
+configurations.consumable("develocityInjectionScript") {
+    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named("develocity-injection-script"))
+    outgoing.artifact(tasks.named<ProcessResources>("processResources")
+        .map { it.destinationDir.resolve("develocity-injection.init.gradle") })
 }

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -145,6 +145,14 @@ void enableDevelocityInjection() {
         return geValue instanceof Closure<?> ? geValue() : geValue
     }
 
+    def printEnforcingDevelocityUrl = {
+        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+    }
+
+    def printAcceptingGradleTermsOfUse = {
+        logger.lifecycle("Accepting Gradle Terms of Use: $buildScanTermsOfUseUrl")
+    }
+
     // finish early if configuration parameters passed in via system properties are not valid/supported
     if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
         logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
@@ -196,39 +204,45 @@ void enableDevelocityInjection() {
                             }
                         }
                     }
+                }
 
-                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                        // Only execute if develocity plugin isn't applied.
-                        if (gradle.rootProject.extensions.findByName("develocity")) return
+                eachDevelocityProjectExtension(project,
+                    { develocity ->
                         afterEvaluate {
                             if (develocityUrl && develocityEnforceUrl) {
-                                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
-                                buildScan.server = develocityUrl
-                                buildScan.allowUntrustedServer = develocityAllowUntrustedServer
-                            }
-                        }
-
-                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                            buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                            buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
-                        }
-                    }
-
-                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                        afterEvaluate {
-                            if (develocityUrl && develocityEnforceUrl) {
-                                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                                printEnforcingDevelocityUrl()
                                 develocity.server = develocityUrl
                                 develocity.allowUntrustedServer = develocityAllowUntrustedServer
                             }
                         }
 
                         if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            printAcceptingGradleTermsOfUse()
                             develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                             develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                         }
+                    },
+                    { buildScan ->
+                        afterEvaluate {
+                            if (develocityUrl && develocityEnforceUrl) {
+                                printEnforcingDevelocityUrl()
+                                buildScan.server = develocityUrl
+                                buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
+                        }
+
+                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                            printAcceptingGradleTermsOfUse()
+                            if (buildScan.metaClass.respondsTo(buildScan, 'setTermsOfServiceUrl', String)) {
+                                buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                                buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                            } else {
+                                buildScan.licenseAgreementUrl = buildScanTermsOfUseUrl
+                                buildScan.licenseAgree = buildScanTermsOfUseAgree
+                            }
+                        }
                     }
-                }
+                )
 
                 if (ccudPluginVersion && atLeastGradle4) {
                     def ccudPluginComponent = resolutionResult.allComponents.find {
@@ -250,8 +264,14 @@ void enableDevelocityInjection() {
                     if (develocityUrl) {
                         logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                         eachDevelocitySettingsExtension(settings) { ext ->
-                            ext.server = develocityUrl
-                            ext.allowUntrustedServer = develocityAllowUntrustedServer
+                            // server and allowUntrustedServer must be configured via buildScan extension for gradle-enterprise-plugin 3.1.1 and earlier
+                            if (ext.metaClass.respondsTo(ext, 'getServer')) {
+                                ext.server = develocityUrl
+                                ext.allowUntrustedServer = develocityAllowUntrustedServer
+                            } else {
+                                ext.buildScan.server = develocityUrl
+                                ext.buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                            }
                         }
                     }
 
@@ -278,34 +298,42 @@ void enableDevelocityInjection() {
                         }
                     )
                 }
+            }
 
-                eachDevelocitySettingsExtension(settings,
-                    { develocity ->
-                        if (develocityUrl && develocityEnforceUrl) {
-                            logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
-                            develocity.server = develocityUrl
-                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
+            eachDevelocitySettingsExtension(settings,
+                { develocity ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        printEnforcingDevelocityUrl()
+                        develocity.server = develocityUrl
+                        develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
 
-                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                            develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
-                            develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
-                        }
-                    },
-                    { gradleEnterprise ->
-                        if (develocityUrl && develocityEnforceUrl) {
-                            logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        printAcceptingGradleTermsOfUse()
+                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                    }
+                },
+                { gradleEnterprise ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        printEnforcingDevelocityUrl()
+                        // server and allowUntrustedServer must be configured via buildScan extension for gradle-enterprise-plugin 3.1.1 and earlier
+                        if (gradleEnterprise.metaClass.respondsTo(gradleEnterprise, 'getServer')) {
                             gradleEnterprise.server = develocityUrl
                             gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
-
-                        if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
-                            gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
-                            gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                        } else {
+                            gradleEnterprise.buildScan.server = develocityUrl
+                            gradleEnterprise.buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                         }
                     }
-                )
-            }
+
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        printAcceptingGradleTermsOfUse()
+                        gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                        gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+                }
+            )
 
             if (ccudPluginVersion) {
                 if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
@@ -364,6 +392,32 @@ static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAct
     }
 }
 
+/**
+ * Apply the `dvAction` to the 'develocity' extension.
+ * If no 'develocity' extension is found, apply the `bsAction` to the 'buildScan' extension.
+ * (The develocity plugin creates both extensions, and we want to prefer configuring 'develocity').
+ */
+static def eachDevelocityProjectExtension(def project, def dvAction, def bsAction = dvAction) {
+    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+
+    def configureDvOrBsExtension = {
+        if (project.extensions.findByName("develocity")) {
+            dvAction(project.develocity)
+        } else {
+            bsAction(project.buildScan)
+        }
+    }
+
+    project.pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID, configureDvOrBsExtension)
+
+    project.pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+        // Proper extension will be configured by the build-scan callback.
+        if (project.pluginManager.hasPlugin(BUILD_SCAN_PLUGIN_ID)) return
+        configureDvOrBsExtension()
+    }
+}
+
 static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
     GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
 }
@@ -373,21 +427,13 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
 }
 
 void enableBuildScanLinkCapture(BuildScanCollector collector) {
-    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
-    def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
-
     // Conditionally apply and configure the Develocity plugin
     if (GradleVersion.current() < GradleVersion.version('6.0')) {
         rootProject {
-            pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                // Only execute if develocity plugin isn't applied.
-                if (gradle.rootProject.extensions.findByName("develocity")) return
-                buildScanPublishedAction(buildScan, collector)
-            }
-
-            pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                buildScanPublishedAction(develocity.buildScan, collector)
-            }
+            eachDevelocityProjectExtension(project,
+                { develocity -> buildScanPublishedAction(develocity.buildScan, collector) },
+                { buildScan  -> buildScanPublishedAction(buildScan, collector) }
+            )
         }
     } else {
         gradle.settingsEvaluated { settings ->

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -90,9 +90,6 @@ abstract class BaseInitScriptTest extends Specification {
             // Only include valid Gradle/Plugin combinations
             dvPlugin.isCompatibleWith(gradleVersion)
         }
-        // TODO: FIX
-        //  Remove case that is currently failing due to a bug in the init-script
-        .findAll { gradleVersion, dvPlugin -> !(dvPlugin.id == 'com.gradle.build-scan' && dvPlugin.version in ['3.17', '3.18.1'])}
     }
 
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -254,6 +254,8 @@ abstract class BaseInitScriptTest extends Specification {
             DEVELOCITY_CCUD_PLUGIN_VERSION            : "develocity.ccud-plugin.version",
             DEVELOCITY_BUILD_SCAN_UPLOAD_IN_BACKGROUND: "develocity.build-scan.upload-in-background",
             DEVELOCITY_CAPTURE_FILE_FINGERPRINTS      : "develocity.capture-file-fingerprints",
+            DEVELOCITY_TERMS_OF_USE_URL               : "develocity.terms-of-use.url",
+            DEVELOCITY_TERMS_OF_USE_AGREE             : "develocity.terms-of-use.agree",
             GRADLE_PLUGIN_REPOSITORY_URL              : "gradle.plugin-repository.url",
             GRADLE_PLUGIN_REPOSITORY_USERNAME         : "gradle.plugin-repository.username",
             GRADLE_PLUGIN_REPOSITORY_PASSWORD         : "gradle.plugin-repository.password",

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -208,6 +208,7 @@ abstract class BaseInitScriptTest extends Specification {
     }
 
     BuildResult run(List<String> args, TestGradleVersion testGradle, Map<String, String> envVars = [:]) {
+        println(envVars)
         def result = createRunner(args, testGradle.gradleVersion, envVars).build()
         assertNoDeprecationWarning(result)
         assertNoStackTraces(result)

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -196,8 +196,6 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
-            // TODO: There is a bug in the init-script, trying to set `gradleEnterprise.server` does not work for GE plugin `v3.0`
-            .findAll {testGradle, testDvPlugin -> !(testDvPlugin.pluginId.id == 'com.gradle.enterprise' && testDvPlugin.version == '3.0')}
     }
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -200,7 +200,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
-        def config = testConfig(testDvPlugin.version).withServer(mockScansServer.address).withAcceptGradleTermsOfUse().withoutDevelocityPluginVersion()
+        def config = testConfig().withAcceptGradleTermsOfUse().withoutDevelocityPluginVersion()
         def result = run(testGradle, config)
 
         then:


### PR DESCRIPTION
This PR widens the scope of Develocity URL enforcement by setting the Develocity server URL even if the Develocity plugin was not applied by the init script. 

This supports the Develocity Build Validation Script `-s` use case. 