### PR TITLE
Develocity Build Validation Scripts repository is updated on release

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -17,4 +17,4 @@ jobs:
 
       - run: ./gradlew build
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate reference script with version
         run: ./gradlew promote -Pversion=${{ inputs.version }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
 
       - name: Commit & push changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -103,3 +103,13 @@ jobs:
       GH_BOT_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # bot-githubaction does not have write access
       GH_BOT_PGP_PRIVATE_KEY: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
       GH_BOT_PGP_PASSPHRASE: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}
+
+  update-develocity-build-validation-scripts:
+    needs: [update-reference]
+    uses: ./.github/workflows/gradle-send-update-pr.yml
+    with:
+      version: ${{ inputs.version }}
+      repository: 'gradle/gradle-enterprise-build-validation-scripts'
+      post-process: |
+        sed -i 's/com\.gradle:develocity-injection:[^"]*/com.gradle:develocity-injection:${{ inputs.version }}/' build.gradle.kts
+    secrets: inherit

--- a/.github/workflows/gradle-send-update-pr.yml
+++ b/.github/workflows/gradle-send-update-pr.yml
@@ -11,7 +11,7 @@ on:
         required: true
       script-location:
         type: string
-        required: true
+        required: false
       post-process:
         type: string
         required: false
@@ -48,6 +48,7 @@ jobs:
           token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}
 
       - name: Copy reference script
+        if: ${{ inputs.script-location }}
         run: cp reference/develocity-injection.init.gradle ${{ inputs.repository }}/${{ inputs.script-location }}
 
       - name: Post-process target repository


### PR DESCRIPTION
This PR adds the Develocity Build Validation Scripts repository to the release workflow. 

The BVS build resolves the init script as a dependency and does not contain an actual copy of it. This is why I needed to make the `script-location` parameter optional.