### PR TITLE
Test more DV plugin versions

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -163,8 +163,8 @@ void enableDevelocityInjection() {
                     }
                     if (!scanPluginComponent) {
                         def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                        logger.lifecycle("Applying $pluginClass via init script")
-                        applyPluginExternally(pluginManager, pluginClass)
+                        def pluginVersion = dvOrGe(develocityPluginVersion, "1.16")
+                        applyPluginExternally(pluginManager, pluginClass, pluginVersion)
                         def rootExtension = dvOrGe(
                             { develocity },
                             { buildScan }
@@ -237,7 +237,7 @@ void enableDevelocityInjection() {
                         it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
                     }
                     if (!ccudPluginComponent) {
-                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
                         pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                     }
                 }
@@ -248,8 +248,7 @@ void enableDevelocityInjection() {
             if (develocityPluginVersion) {
                 if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
                     def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                    logger.lifecycle("Applying $pluginClass via init script")
-                    applyPluginExternally(settings.pluginManager, pluginClass)
+                    applyPluginExternally(settings.pluginManager, pluginClass, develocityPluginVersion)
                     if (develocityUrl) {
                         logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                         eachDevelocitySettingsExtension(settings) { ext ->
@@ -314,7 +313,7 @@ void enableDevelocityInjection() {
 
             if (ccudPluginVersion) {
                 if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
+                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
                     settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                 }
             }
@@ -322,7 +321,9 @@ void enableDevelocityInjection() {
     }
 }
 
-void applyPluginExternally(def pluginManager, String pluginClassName) {
+void applyPluginExternally(def pluginManager, String pluginClassName, String pluginVersion) {
+    logger.lifecycle("Applying $pluginClassName with version $pluginVersion via init script")
+
     def externallyApplied = 'develocity.externally-applied'
     def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
     def oldValue = System.getProperty(externallyApplied)

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -197,15 +197,12 @@ void enableDevelocityInjection() {
                         }
                     }
 
-                    if (develocityUrl && develocityEnforceUrl) {
-                        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                    }
-
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         // Only execute if develocity plugin isn't applied.
                         if (gradle.rootProject.extensions.findByName("develocity")) return
                         afterEvaluate {
                             if (develocityUrl && develocityEnforceUrl) {
+                                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                                 buildScan.server = develocityUrl
                                 buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                             }
@@ -220,6 +217,7 @@ void enableDevelocityInjection() {
                     pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
                         afterEvaluate {
                             if (develocityUrl && develocityEnforceUrl) {
+                                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                                 develocity.server = develocityUrl
                                 develocity.allowUntrustedServer = develocityAllowUntrustedServer
                             }
@@ -281,13 +279,10 @@ void enableDevelocityInjection() {
                     )
                 }
 
-                if (develocityUrl && develocityEnforceUrl) {
-                    logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
-                }
-
                 eachDevelocitySettingsExtension(settings,
                     { develocity ->
                         if (develocityUrl && develocityEnforceUrl) {
+                            logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
@@ -299,6 +294,7 @@ void enableDevelocityInjection() {
                     },
                     { gradleEnterprise ->
                         if (develocityUrl && develocityEnforceUrl) {
+                            logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                             gradleEnterprise.server = develocityUrl
                             gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
                         }

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -163,7 +163,7 @@ void enableDevelocityInjection() {
                     }
                     if (!scanPluginComponent) {
                         def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
-                        def pluginVersion = dvOrGe(develocityPluginVersion, "1.16")
+                        def pluginVersion = atLeastGradle5 ? develocityPluginVersion : "1.16"
                         applyPluginExternally(pluginManager, pluginClass, pluginVersion)
                         def rootExtension = dvOrGe(
                             { develocity },

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -51,11 +51,10 @@ abstract class BaseInitScriptTest extends Specification {
 
         dvPlugin(GRADLE_ENTERPRISE, DEVELOCITY_PLUGIN_VERSION, true),
         dvPlugin(GRADLE_ENTERPRISE, '3.17', true),
-        dvPlugin(GRADLE_ENTERPRISE, '3.16.2'),
-        dvPlugin(GRADLE_ENTERPRISE, '3.6.4'),
-        dvPlugin(GRADLE_ENTERPRISE, '3.3.4'), // Has background build-scan upload
-        dvPlugin(GRADLE_ENTERPRISE, '3.2.1'), // Has 'gradleEnterprise.server' element
-        dvPlugin(GRADLE_ENTERPRISE, '3.1.1'), // Has 'gradleEnterprise.buildScan.server' value
+        dvPlugin(GRADLE_ENTERPRISE, '3.16.2'),  // Last version before DV
+        dvPlugin(GRADLE_ENTERPRISE, '3.11.1'), // Oldest version compatible with CCUD 2.0.2
+        dvPlugin(GRADLE_ENTERPRISE, '3.3.4'), // Introduced background build-scan upload
+        dvPlugin(GRADLE_ENTERPRISE, '3.2.1'), // Introduced 'gradleEnterprise.server' element
         dvPlugin(GRADLE_ENTERPRISE, '3.0'), // Earliest version of `com.gradle.enterprise` plugin
 
         dvPlugin(BUILD_SCAN, DEVELOCITY_PLUGIN_VERSION, true),
@@ -397,8 +396,17 @@ abstract class BaseInitScriptTest extends Specification {
         }
 
         String getCompatibleCCUDVersion() {
-            // CCUD 1.13 is compatible with pre-develocity plugins
-            return pluginVersionAtLeast('3.17') ? CCUD_PLUGIN_VERSION : '1.13'
+            if (pluginVersionAtLeast('3.11')) {
+                return CCUD_PLUGIN_VERSION
+            }
+            if (pluginVersionAtLeast('3.2')) {
+                return '1.13'
+            }
+            if (pluginId == BUILD_SCAN && version == '1.16') {
+                return '1.13'
+            }
+            // No known compatible CCUD for older plugin versions
+            return null
         }
 
         private boolean pluginVersionAtLeast(String targetVersion) {

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -27,7 +27,7 @@ abstract class BaseInitScriptTest extends Specification {
     static final TestGradleVersion GRADLE_8_0 = new TestGradleVersion(GradleVersion.version('8.0.2'), 8, 19)
     static final TestGradleVersion GRADLE_8_X = new TestGradleVersion(GradleVersion.version('8.7'), 8, 21)
 
-    static final List<TestGradleVersion> ALL_VERSIONS = [
+    static final List<TestGradleVersion> ALL_GRADLE_VERSIONS = [
         GRADLE_3_X, // First version where TestKit supports environment variables
         GRADLE_4_X,
         GRADLE_5_X,
@@ -37,11 +37,21 @@ abstract class BaseInitScriptTest extends Specification {
         GRADLE_8_X,
     ]
 
-    static final List<TestGradleVersion> CONFIGURATION_CACHE_VERSIONS =
-        [GRADLE_7_X, GRADLE_8_0, GRADLE_8_X].intersect(ALL_VERSIONS)
+    static final List<TestGradleVersion> CONFIGURATION_CACHE_GRADLE_VERSIONS =
+        [GRADLE_7_X, GRADLE_8_0, GRADLE_8_X].intersect(ALL_GRADLE_VERSIONS)
 
-    static final List<TestGradleVersion> SETTINGS_PLUGIN_VERSIONS =
-        [GRADLE_6_X, GRADLE_7_X, GRADLE_8_0, GRADLE_8_X].intersect(ALL_VERSIONS)
+    // Gradle + plugin versions to test DV injection: used to test with project with no DV plugin defined
+    static def getVersionsToTestForPluginInjection(List<TestGradleVersion> gradleVersions = ALL_GRADLE_VERSIONS) {
+        [
+            gradleVersions,
+            [
+                "3.6.4", // Support server back to GE 2021.1
+                "3.16.2", // Last version before switch to Develocity
+                "3.17", // First Develocity plugin
+                DEVELOCITY_PLUGIN_VERSION // Latest Develocity plugin
+            ]
+        ].combinations()
+    }
 
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
     static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -179,11 +179,11 @@ abstract class BaseInitScriptTest extends Specification {
         buildFile << ''
     }
 
-    void declareDvPluginApplication(GradleVersion gradleVersion, TestDvPluginVersion dvPlugin, String ccudPluginVersion = null, URI serverUri = mockScansServer.address) {
+    void declareDvPluginApplication(TestGradleVersion testGradle, TestDvPluginVersion dvPlugin, String ccudPluginVersion = null, URI serverUri = mockScansServer.address) {
         if (dvPlugin.deprecated) {
             allowDevelocityDeprecationWarning = true
         }
-        if (gradleVersion < GRADLE_6) {
+        if (testGradle.gradleVersion < GRADLE_6) {
             buildFile.text = configuredPlugin(dvPlugin, ccudPluginVersion, serverUri)
         } else {
             settingsFile.text = configuredPlugin(dvPlugin, ccudPluginVersion, serverUri)
@@ -200,8 +200,8 @@ abstract class BaseInitScriptTest extends Specification {
             """
     }
 
-    BuildResult run(List<String> args, GradleVersion gradleVersion = GradleVersion.current(), Map<String, String> envVars = [:]) {
-        def result = createRunner(args, gradleVersion, envVars).build()
+    BuildResult run(List<String> args, TestGradleVersion testGradle, Map<String, String> envVars = [:]) {
+        def result = createRunner(args, testGradle.gradleVersion, envVars).build()
         assertNoDeprecationWarning(result)
     }
 

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -213,6 +213,7 @@ abstract class BaseInitScriptTest extends Specification {
     BuildResult run(List<String> args, TestGradleVersion testGradle, Map<String, String> envVars = [:]) {
         def result = createRunner(args, testGradle.gradleVersion, envVars).build()
         assertNoDeprecationWarning(result)
+        assertNoStackTraces(result)
     }
 
     GradleRunner createRunner(List<String> args, GradleVersion gradleVersion = GradleVersion.current(), Map<String, String> envVars = [:]) {
@@ -272,6 +273,11 @@ abstract class BaseInitScriptTest extends Specification {
         if (!allowDevelocityDeprecationWarning) {
             assert !result.output.contains("WARNING: The following functionality has been deprecated")
         }
+        return result
+    }
+
+    BuildResult assertNoStackTraces(BuildResult result) {
+        assert !result.output.contains("Exception:")
         return result
     }
 
@@ -399,10 +405,10 @@ abstract class BaseInitScriptTest extends Specification {
             if (pluginVersionAtLeast('3.11')) {
                 return CCUD_PLUGIN_VERSION
             }
-            if (pluginVersionAtLeast('3.2')) {
-                return '1.13'
-            }
             if (pluginId == BUILD_SCAN && version == '1.16') {
+                return CCUD_PLUGIN_VERSION
+            }
+            if (pluginVersionAtLeast('3.6')) {
                 return '1.13'
             }
             // No known compatible CCUD for older plugin versions

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -5,76 +5,76 @@ import spock.lang.Requires
 
 class TestBuildScanCapture extends BaseInitScriptTest {
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not capture build scan url when init-script not enabled"() {
         given:
         captureBuildScanLinks()
 
         when:
-        def result = run(['help'], testGradleVersion.gradleVersion, [:])
+        def result = run(['help'], testGradle, [:])
 
         then:
         buildScanUrlIsNotCaptured(result)
 
         where:
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        testGradle << ALL_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can capture build scan url with develocity injection"() {
         given:
         captureBuildScanLinks()
 
         when:
-        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testDvPluginVersion.version)
-        def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
+        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testDvPlugin.version)
+        def result = run(['help'], testGradle, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         where:
-        [testGradleVersion, testDvPluginVersion] << versionsToTestForPluginInjection
+        [testGradle, testDvPlugin] << versionsToTestForPluginInjection
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can capture build scan url without develocity injection"() {
         given:
         captureBuildScanLinks()
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
+        declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
         def config = new MinimalTestConfig()
-        def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
+        def result = run(['help'], testGradle, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin()
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
     }
 
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can capture build scan url with config-cache enabled"() {
         given:
         captureBuildScanLinks()
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
+        declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
         def config = new MinimalTestConfig()
-        def result = run(['help', '--configuration-cache'], testGradleVersion.gradleVersion, config.envVars)
+        def result = run(['help', '--configuration-cache'], testGradle, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         when:
-        result = run(['help', '--configuration-cache'], testGradleVersion.gradleVersion, config.envVars)
+        result = run(['help', '--configuration-cache'], testGradle, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin(CONFIGURATION_CACHE_GRADLE_VERSIONS)
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CONFIGURATION_CACHE_GRADLE_VERSIONS)
             .findAll { gradleVersion, dvPlugin -> dvPlugin.isCompatibleWithConfigurationCache() }
     }
 

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -17,7 +17,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         buildScanUrlIsNotCaptured(result)
 
         where:
-        testGradleVersion << ALL_VERSIONS
+        testGradleVersion << ALL_GRADLE_VERSIONS
     }
 
     @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
@@ -26,14 +26,14 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         captureBuildScanLinks()
 
         when:
-        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, DEVELOCITY_PLUGIN_VERSION)
+        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testPluginVersion)
         def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         where:
-        testGradleVersion << ALL_VERSIONS
+        [testGradleVersion, testPluginVersion] << versionsToTestForPluginInjection
     }
 
     @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
@@ -50,7 +50,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         buildScanUrlIsCaptured(result)
 
         where:
-        testGradleVersion << ALL_VERSIONS
+        testGradleVersion << ALL_GRADLE_VERSIONS
     }
 
 
@@ -74,7 +74,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         buildScanUrlIsCaptured(result)
 
         where:
-        testGradleVersion << CONFIGURATION_CACHE_VERSIONS
+        testGradleVersion << CONFIGURATION_CACHE_GRADLE_VERSIONS
     }
 
     void buildScanUrlIsCaptured(BuildResult result) {

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -26,21 +26,21 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         captureBuildScanLinks()
 
         when:
-        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testPluginVersion)
+        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testDvPluginVersion.version)
         def result = run(['help'], testGradleVersion.gradleVersion, config.envVars)
 
         then:
         buildScanUrlIsCaptured(result)
 
         where:
-        [testGradleVersion, testPluginVersion] << versionsToTestForPluginInjection
+        [testGradleVersion, testDvPluginVersion] << versionsToTestForPluginInjection
     }
 
     @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
     def "can capture build scan url without develocity injection"() {
         given:
         captureBuildScanLinks()
-        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
+        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
 
         when:
         def config = new MinimalTestConfig()
@@ -50,7 +50,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         buildScanUrlIsCaptured(result)
 
         where:
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin()
     }
 
 
@@ -58,7 +58,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
     def "can capture build scan url with config-cache enabled"() {
         given:
         captureBuildScanLinks()
-        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
+        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
 
         when:
         def config = new MinimalTestConfig()
@@ -74,7 +74,8 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         buildScanUrlIsCaptured(result)
 
         where:
-        testGradleVersion << CONFIGURATION_CACHE_GRADLE_VERSIONS
+        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin(CONFIGURATION_CACHE_GRADLE_VERSIONS)
+            .findAll { gradleVersion, dvPlugin -> dvPlugin.isCompatibleWithConfigurationCache() }
     }
 
     void buildScanUrlIsCaptured(BuildResult result) {

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -7,26 +7,26 @@ import spock.lang.Requires
 class TestDevelocityInjection extends BaseInitScriptTest {
     static final List<TestGradleVersion> CCUD_COMPATIBLE_GRADLE_VERSIONS = ALL_GRADLE_VERSIONS - [GRADLE_3_X]
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not apply Develocity plugins when not requested"() {
         when:
-        def result = run([], testGradleVersion.gradleVersion)
+        def result = run([], testGradle)
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         where:
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        testGradle << ALL_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not override Develocity plugin when already defined in project"() {
         given:
-        declareDvPluginApplication(testGradleVersion.gradleVersion, pluginVersion)
+        declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
-        def result = run(testGradleVersion, testConfig())
+        def result = run(testGradle, testConfig())
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -36,50 +36,50 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, pluginVersion] << getVersionsToTestForExistingDvPlugin()
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "applies Develocity plugin via init script when not defined in project"() {
         when:
-        def result = run(testGradleVersion, testConfig(testPluginVersion.version))
+        def result = run(testGradle, testConfig(testDvPlugin.version))
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion, testPluginVersion.version)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion, testDvPlugin.version)
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, testPluginVersion] << getVersionsToTestForPluginInjection()
+        [testGradle, testDvPlugin] << getVersionsToTestForPluginInjection()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "applies Develocity and CCUD plugins via init script when not defined in project"() {
         when:
-        def ccudPluginVersion = pluginVersion.compatibleCCUDVersion
-        def result = run(testGradleVersion, testConfig(pluginVersion.version).withCCUDPlugin(ccudPluginVersion))
+        def ccudPluginVersion = testDvPlugin.compatibleCCUDVersion
+        def result = run(testGradle, testConfig(testDvPlugin.version).withCCUDPlugin(ccudPluginVersion))
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion, pluginVersion.version)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion, testDvPlugin.version)
         outputContainsCcudPluginApplicationViaInitScript(result, ccudPluginVersion)
 
         and:
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, pluginVersion] << getVersionsToTestForPluginInjection(CCUD_COMPATIBLE_GRADLE_VERSIONS)
+        [testGradle, testDvPlugin] << getVersionsToTestForPluginInjection(CCUD_COMPATIBLE_GRADLE_VERSIONS)
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "applies CCUD plugin via init script where Develocity plugin already applied"() {
         given:
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
+        declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
-        def ccudPluginVersion = dvPlugin.compatibleCCUDVersion
-        def result = run(testGradleVersion, testConfig().withCCUDPlugin(ccudPluginVersion))
+        def ccudPluginVersion = testDvPlugin.compatibleCCUDVersion
+        def result = run(testGradle, testConfig().withCCUDPlugin(ccudPluginVersion))
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -89,16 +89,16 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not override CCUD plugin when already defined in project"() {
         given:
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin, dvPlugin.compatibleCCUDVersion)
+        declareDvPluginApplication(testGradle, testDvPlugin, testDvPlugin.compatibleCCUDVersion)
 
         when:
-        def result = run(testGradleVersion, testConfig().withCCUDPlugin(CCUD_PLUGIN_VERSION))
+        def result = run(testGradle, testConfig().withCCUDPlugin(CCUD_PLUGIN_VERSION))
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -108,17 +108,17 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "ignores Develocity URL and allowUntrustedServer when Develocity plugin is already defined in project"() {
         given:
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin)
+        declareDvPluginApplication(testGradle, testDvPlugin)
 
         when:
         def config = testConfig().withServer(URI.create('https://develocity-server.invalid'))
-        def result = run(testGradleVersion, config)
+        def result = run(testGradle, config)
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -128,17 +128,17 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin()
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "configures Develocity URL and allowUntrustedServer when Develocity plugin is applied by the init script"() {
         when:
-        def config = testConfig(testPluginVersion.version).withServer(mockScansServer.address)
-        def result = run(testGradleVersion, config)
+        def config = testConfig(testDvPlugin.version).withServer(mockScansServer.address)
+        def result = run(testGradle, config)
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion, testPluginVersion.version)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion, testDvPlugin.version)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
         outputContainsPluginRepositoryInfo(result, 'https://plugins.gradle.org/m2')
@@ -147,20 +147,20 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, testPluginVersion] << getVersionsToTestForPluginInjection()
+        [testGradle, testDvPlugin] << getVersionsToTestForPluginInjection()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can configure capturing file fingerprints when Develocity plugin is applied by the init script"() {
         when:
-        def config = testConfig(testPluginVersion.version).withCaptureFileFingerprints()
-        def result = run(testGradleVersion, config)
+        def config = testConfig(testDvPlugin.version).withCaptureFileFingerprints()
+        def result = run(testGradle, config)
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion, testPluginVersion.version)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion, testDvPlugin.version)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
-        if (testGradleVersion.gradleVersion > GRADLE_5) {
+        if (testGradle.gradleVersion > GRADLE_5) {
             outputCaptureFileFingerprints(result, true)
         }
 
@@ -168,17 +168,17 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, testPluginVersion] << getVersionsToTestForPluginInjection()
+        [testGradle, testDvPlugin] << getVersionsToTestForPluginInjection()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "enforces Develocity URL and allowUntrustedServer in project with DV plugin already defined if enforce url parameter is enabled"() {
         given:
-        declareDvPluginApplication(testGradleVersion.gradleVersion, dvPlugin, null, URI.create('https://develocity-server.invalid'))
+        declareDvPluginApplication(testGradle, testDvPlugin, null, URI.create('https://develocity-server.invalid'))
 
         when:
         def config = testConfig().withServer(mockScansServer.address, true)
-        def result = run(testGradleVersion, config)
+        def result = run(testGradle, config)
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -191,17 +191,17 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        [testGradleVersion, dvPlugin] << getVersionsToTestForExistingDvPlugin()
+        [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can configure alternative repository for plugins when Develocity plugin is applied by the init script"() {
         when:
         def config = testConfig().withPluginRepository(new URI('https://plugins.grdev.net/m2'))
-        def result = run(testGradleVersion, config)
+        def result = run(testGradle, config)
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
         outputContainsPluginRepositoryInfo(result, 'https://plugins.grdev.net/m2')
@@ -211,17 +211,17 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         // Plugin repository is unrelated to DV plugin, so only test with latest DV plugin version
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        testGradle << ALL_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can configure alternative repository for plugins with credentials when Develocity plugin is applied by the init script"() {
         when:
         def config = testConfig().withPluginRepository(new URI('https://plugins.grdev.net/m2')).withPluginRepositoryCredentials("john", "doe")
-        def result = run(testGradleVersion, config)
+        def result = run(testGradle, config)
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
         outputContainsPluginRepositoryInfo(result, 'https://plugins.grdev.net/m2', true)
@@ -231,14 +231,14 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         // Plugin repository is unrelated to DV plugin, so only test with latest DV plugin version
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        testGradle << ALL_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "stops gracefully when requested CCUD plugin version is <1.7"() {
         when:
         def config = testConfig().withCCUDPlugin("1.6.6")
-        def result = run(testGradleVersion, config)
+        def result = run(testGradle, config)
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -246,41 +246,41 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         result.output.contains('Common Custom User Data Gradle plugin must be at least 1.7. Configured version is 1.6.6.')
 
         where:
-        testGradleVersion << ALL_GRADLE_VERSIONS
+        testGradle << ALL_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "can configure Develocity via CCUD system property overrides when plugins are injected via init script"() {
         when:
         def config = testConfig().withCCUDPlugin().withServer(URI.create('https://develocity-server.invalid'))
-        def result = run(testGradleVersion, config, ["help", "-Ddevelocity.url=${mockScansServer.address}".toString()])
+        def result = run(testGradle, config, ["help", "-Ddevelocity.url=${mockScansServer.address}".toString()])
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
         outputContainsCcudPluginApplicationViaInitScript(result)
 
         and:
         outputContainsBuildScanUrl(result)
 
         where:
-        testGradleVersion << CCUD_COMPATIBLE_GRADLE_VERSIONS
+        testGradle << CCUD_COMPATIBLE_GRADLE_VERSIONS
     }
 
-    @Requires({data.testGradleVersion.compatibleWithCurrentJvm})
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "init script is configuration cache compatible"() {
         when:
         def config = testConfig().withCCUDPlugin()
-        def result = run(testGradleVersion, config, ["help", "--configuration-cache"])
+        def result = run(testGradle, config, ["help", "--configuration-cache"])
 
         then:
-        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
         outputContainsCcudPluginApplicationViaInitScript(result)
 
         and:
         outputContainsBuildScanUrl(result)
 
         when:
-        result = run(testGradleVersion, config, ["help", "--configuration-cache"])
+        result = run(testGradle, config, ["help", "--configuration-cache"])
 
         then:
         outputMissesDevelocityPluginApplicationViaInitScript(result)
@@ -290,7 +290,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsBuildScanUrl(result)
 
         where:
-        testGradleVersion << CONFIGURATION_CACHE_GRADLE_VERSIONS
+        testGradle << CONFIGURATION_CACHE_GRADLE_VERSIONS
     }
 
     void outputContainsBuildScanUrl(BuildResult result) {
@@ -372,8 +372,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert 1 == result.output.count(enforceUrl)
     }
 
-    private BuildResult run(TestGradleVersion testGradleVersion, DvInjectionTestConfig config, List<String> args = ["help"]) {
-        return run(args, testGradleVersion.gradleVersion, config.envVars)
+    private BuildResult run(TestGradleVersion testGradle, DvInjectionTestConfig config, List<String> args = ["help"]) {
+        return run(args, testGradle, config.envVars)
     }
 
     DvInjectionTestConfig testConfig(String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -307,14 +307,20 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
     void outputContainsDevelocityPluginApplicationViaInitScript(BuildResult result, GradleVersion gradleVersion, String pluginVersion = DEVELOCITY_PLUGIN_VERSION) {
         def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin with version 1.16 via init script"
+        def pluginApplicationLogMsgBuildScanPlugin = "Applying com.gradle.scan.plugin.BuildScanPlugin with version ${pluginVersion} via init script"
         def pluginApplicationLogMsgGEPlugin = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin with version ${pluginVersion} via init script"
         def pluginApplicationLogMsgDVPlugin = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin with version ${pluginVersion} via init script"
 
         def isGEPluginVersion = GradleVersion.version(pluginVersion) < GradleVersion.version("3.17")
 
-        if (gradleVersion < GRADLE_5 || (gradleVersion < GRADLE_6 && isGEPluginVersion)) {
+        if (gradleVersion < GRADLE_5) {
             assert result.output.contains(pluginApplicationLogMsgGradle4)
             assert 1 == result.output.count(pluginApplicationLogMsgGradle4)
+            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
+        } else if (gradleVersion < GRADLE_6 && isGEPluginVersion) {
+            assert result.output.contains(pluginApplicationLogMsgBuildScanPlugin)
+            assert 1 == result.output.count(pluginApplicationLogMsgBuildScanPlugin)
             assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
             assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
         } else if (isGEPluginVersion) {

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -90,6 +90,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
+            // Ignore test for old versions of plugin where no CCUD works.
+            .findAll {testGradle, testDvPlugin -> testDvPlugin.compatibleCCUDVersion != null}
     }
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})
@@ -109,6 +111,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
+            // Ignore test for old versions of plugin where no CCUD works.
+            .findAll {testGradle, testDvPlugin -> testDvPlugin.compatibleCCUDVersion != null}
     }
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})
@@ -192,6 +196,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin()
+            // TODO: There is a bug in the init-script, trying to set `gradleEnterprise.server` does not work for GE plugin `v3.0`
+            .findAll {testGradle, testDvPlugin -> !(testDvPlugin.pluginId.id == 'com.gradle.enterprise' && testDvPlugin.version == '3.0')}
     }
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})


### PR DESCRIPTION
This PR extends coverage of the init-script to include more plugin versions.

These tests exposed an issue when enforcing the DV URL on a project that already
applies the `com.gradle.build-scan:[3.17,3.18.1]` plugin. 
As such, [these versions are excluded from testing](https://github.com/gradle/develocity-ci-injection/pull/13/files#diff-756647b4a0b9e3cc3768fa2a2fb445a9c26924084a4362a0145f7ce1d973b9e2R95-R97) for now.

We do not test early versions of the GE/BuildScan plugins, since the mock server protocol
appears to have changed. This will require fixing to expand the coverage further.
