### PR TITLE
System properties are also read using `gradle.startParameter`

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -12,29 +12,29 @@ initscript {
         return
     }
 
-    def getInputParam = { String name ->
+    def getInputParam = { Gradle gradle, String name ->
         def ENV_VAR_PREFIX = ''
         def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-        return System.getProperty(name) ?: System.getenv(envVarName)
+        return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
     }
 
-    def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+    def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
     def initScriptName = buildscript.sourceFile.name
     if (requestedInitScriptName != initScriptName) {
         return
     }
 
     // Plugin loading is only required for Develocity injection. Abort early if not enabled.
-    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
     if (!develocityInjectionEnabled) {
         return
     }
 
-    def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
-    def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
-    def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
-    def develocityPluginVersion = getInputParam('develocity.plugin.version')
-    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+    def pluginRepositoryUrl = getInputParam(gradle, 'gradle.plugin-repository.url')
+    def pluginRepositoryUsername = getInputParam(gradle, 'gradle.plugin-repository.username')
+    def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
+    def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
+    def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -79,10 +79,10 @@ initscript {
     }
 }
 
-static getInputParam(String name) {
+static getInputParam(Gradle gradle, String name) {
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return System.getProperty(name) ?: System.getenv(envVarName)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
 }
 
 def isTopLevelBuild = !gradle.parent
@@ -90,14 +90,14 @@ if (!isTopLevelBuild) {
     return
 }
 
-def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
 def initScriptName = buildscript.sourceFile.name
 if (requestedInitScriptName != initScriptName) {
     logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
     return
 }
 
-def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam("develocity.injection-enabled"))
+def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
 if (develocityInjectionEnabled) {
     enableDevelocityInjection()
 }
@@ -123,16 +123,16 @@ void enableDevelocityInjection() {
     def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
     def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 
-    def develocityUrl = getInputParam('develocity.url')
-    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
-    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-    def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
-    def develocityPluginVersion = getInputParam('develocity.plugin.version')
-    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
-    def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
-    def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
-    def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
+    def develocityUrl = getInputParam(gradle, 'develocity.url')
+    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity.allow-untrusted-server'))
+    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity.enforce-url'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity.build-scan.upload-in-background'))
+    def develocityCaptureFileFingerprints = getInputParam(gradle, 'develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam(gradle, 'develocity.capture-file-fingerprints')) : true
+    def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
+    def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
+    def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity.terms-of-use.url')
+    def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity.terms-of-use.agree')
+    def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity.auto-injection.custom-value')
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -100,9 +100,11 @@ abstract class BaseInitScriptTest extends Specification {
 
     File settingsFile
     File buildFile
+    File gradleProperties
     File initScriptFile
 
     boolean allowDevelocityDeprecationWarning = false
+    boolean usingSystemProperties = false
 
     @TempDir
     File testProjectDir
@@ -181,9 +183,11 @@ abstract class BaseInitScriptTest extends Specification {
 
         settingsFile = new File(testProjectDir, 'settings.gradle')
         buildFile = new File(testProjectDir, 'build.gradle')
+        gradleProperties = new File(testProjectDir, 'gradle.properties')
 
         settingsFile << "rootProject.name = '${ROOT_PROJECT_NAME}'\n"
         buildFile << ''
+        gradleProperties << ''
     }
 
     void declareDvPluginApplication(TestGradleVersion testGradle, TestDvPluginVersion dvPlugin, String ccudPluginVersion = null, URI serverUri = mockScansServer.address) {
@@ -220,13 +224,12 @@ abstract class BaseInitScriptTest extends Specification {
         def runner = ((DefaultGradleRunner) GradleRunner.create())
             .withGradleVersion(gradleVersion.version)
             .withProjectDir(testProjectDir)
-            .withArguments(args)
             .forwardOutput()
 
-        if (testKitSupportsEnvVars(gradleVersion)) {
-            runner.withEnvironment(envVars)
+        if (testKitSupportsEnvVars(gradleVersion) && !usingSystemProperties) {
+            runner.withArguments(args).withEnvironment(envVars)
         } else {
-            (runner as DefaultGradleRunner).withJvmArguments(mapEnvVarsToSystemProps(envVars))
+            runner.withArguments(mapEnvVarsToSystemProps(envVars) + args)
         }
 
         runner

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -333,6 +333,22 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     }
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})
+    def "can apply Develocity plugin using system properties via init script when org.gradle.jvmargs are defined"() {
+        given:
+        gradleProperties.text = 'org.gradle.jvmargs=-Dfile.encoding=UTF-8'
+        usingSystemProperties = true
+
+        when:
+        def result = run(testGradle, testConfig())
+
+        then:
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
+
+        where:
+        testGradle << ALL_GRADLE_VERSIONS
+    }
+
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "init script is configuration cache compatible"() {
         when:
         def config = testConfig().withCCUDPlugin()


### PR DESCRIPTION
Gradle 7.0.2 and earlier cannot reliably read system properties using `System.getProperty` from init scripts. This PR adds reading system properties using the `gradle.startParameter.systemPropertiesArgs` API.

Related BVS PR: https://github.com/gradle/gradle-enterprise-build-validation-scripts/pull/682