### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -100,7 +100,7 @@ jobs:
     uses: ./.github/workflows/gradle-send-update-pr.yml
     with:
       version: ${{ inputs.version }}
-      repository: 'gradle/gradle-enterprise-build-validation-scripts'
+      repository: 'gradle/develocity-build-validation-scripts'
       post-process: |
         sed -i 's/com\.gradle:develocity-injection:[^"]*/com.gradle:develocity-injection:${{ inputs.version }}/' build.gradle.kts
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ The following Develocity CI integrations leverage the Gradle init-script from th
 
 The following Develocity tooling also leverages this init-script.
 
-- [Develocity Build Validation Scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts)
+- [Develocity Build Validation Scripts](https://github.com/gradle/develocity-build-validation-scripts)


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts