### PR TITLE
Bump references to Common Custom User Data Gradle plugin from 2.0.2 to 2.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.gradle.develocity") version("3.18.2")
-    id("com.gradle.common-custom-user-data-gradle-plugin") version("2.0.2")
+    id("com.gradle.common-custom-user-data-gradle-plugin") version("2.1")
 }
 
 develocity {

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -22,7 +22,7 @@ abstract class BaseInitScriptTest extends Specification {
     static final GradleVersion GRADLE_6 = GradleVersion.version('6.0')
 
     static final String DEVELOCITY_PLUGIN_VERSION = '3.18.2'
-    static final String CCUD_PLUGIN_VERSION = '2.0.2'
+    static final String CCUD_PLUGIN_VERSION = '2.1'
 
     static final TestGradleVersion GRADLE_3_X = new TestGradleVersion(GradleVersion.version('3.5.1'), 7, 9)
     static final TestGradleVersion GRADLE_4_X = new TestGradleVersion(GradleVersion.version('4.10.3'), 7, 10)


### PR DESCRIPTION
The version upgrade workflow was failing to create the PR due to the team name change, but the branch was still created. Manually opening the PR and we are fixing the version upgrade workflow.