### PR TITLE
`uploadInBackground` can be configured even Develocity plugin is already applied

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -110,7 +110,6 @@ if (buildScanCaptureEnabled) {
 }
 
 void enableDevelocityInjection() {
-    def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
     def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
     def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
@@ -190,8 +189,6 @@ void enableDevelocityInjection() {
                             // Develocity plugin publishes scans by default
                             buildScanExtension.publishAlways()
                         }
-                        // uploadInBackground not available for build-scan-plugin 1.16
-                        if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
                         buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                         if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
                             logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
@@ -221,6 +218,9 @@ void enableDevelocityInjection() {
                             develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                             develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                         }
+
+                        logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                        develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                     },
                     { buildScan ->
                         afterEvaluate {
@@ -240,6 +240,12 @@ void enableDevelocityInjection() {
                                 buildScan.licenseAgreementUrl = buildScanTermsOfUseUrl
                                 buildScan.licenseAgree = buildScanTermsOfUseAgree
                             }
+                        }
+
+                        // uploadInBackground available for build-scan-plugin 3.3.4 and later only
+                        if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) {
+                            logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                            buildScan.uploadInBackground = buildScanUploadInBackground
                         }
                     }
                 )
@@ -276,7 +282,6 @@ void enableDevelocityInjection() {
                     }
 
                     eachDevelocitySettingsExtension(settings) { ext ->
-                        ext.buildScan.uploadInBackground = buildScanUploadInBackground
                         ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                     }
 
@@ -313,6 +318,9 @@ void enableDevelocityInjection() {
                         develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
                         develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                     }
+
+                    logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                    develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                 },
                 { gradleEnterprise ->
                     if (develocityUrl && develocityEnforceUrl) {
@@ -331,6 +339,12 @@ void enableDevelocityInjection() {
                         printAcceptingGradleTermsOfUse()
                         gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
                         gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+
+                    // uploadInBackground available for gradle-enterprise-plugin 3.3.4 and later only
+                    if (gradleEnterprise.buildScan.metaClass.respondsTo(gradleEnterprise.buildScan, 'setUploadInBackground', Boolean)) {
+                        logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                        gradleEnterprise.buildScan.uploadInBackground = buildScanUploadInBackground
                     }
                 }
             )

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -368,6 +368,14 @@ abstract class BaseInitScriptTest extends Specification {
             return pluginId != BUILD_SCAN && pluginVersionAtLeast('3.16')
         }
 
+        boolean isCompatibleWithUploadInBackground() {
+            if (pluginId == BUILD_SCAN || pluginId == GRADLE_ENTERPRISE) {
+                // Only BS & GE plugins 3.3.4+ support uploadInBackground
+                return pluginVersionAtLeast('3.3.4')
+            }
+            return true
+        }
+
         String getConfigBlock(URI serverUri) {
             switch (pluginId) {
                 case DEVELOCITY:


### PR DESCRIPTION
This PR allows the `uploadInBackground` setting to be configured even if the project already applies the Develocity plugin.

This is necessary for the Develocity Build Validation Scripts, but could also be useful for CI plugins. 

Where this will change behavior for CI users is if the project is currently configuring `uploadInBackground = true` on CI. The CI plugins disable this if configured to do so.