### PR TITLE
Most logging is reduced to `info` level by default

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -91,16 +91,15 @@ if (!isTopLevelBuild) {
     return
 }
 
-def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
 def initScriptName = buildscript.sourceFile.name
-if (requestedInitScriptName != initScriptName) {
-    logger.log(logLevel, "Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
-    return
-}
 
 def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
 if (develocityInjectionEnabled) {
+    if (requestedInitScriptName != initScriptName) {
+        logger.log(LogLevel.WARN, "Develocity injection not enabled because requested init script name was '${requestedInitScriptName}', but '${initScriptName}' was expected")
+        return
+    }
     enableDevelocityInjection()
 }
 
@@ -108,6 +107,10 @@ if (develocityInjectionEnabled) {
 def buildScanCollector = new BuildScanCollector()
 def buildScanCaptureEnabled = buildScanCollector.metaClass.respondsTo(buildScanCollector, 'captureBuildScanLink', String)
 if (buildScanCaptureEnabled) {
+    if (requestedInitScriptName != initScriptName) {
+        logger.log(LogLevel.WARN, "Build Scan capture not enabled because requested init script name was '${requestedInitScriptName}', but '${initScriptName}' was expected")
+        return
+    }
     enableBuildScanLinkCapture(buildScanCollector)
 }
 

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -35,19 +35,20 @@ initscript {
     def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
     def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
     def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
     if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
         pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
-        logger.lifecycle("Develocity plugins resolution: $pluginRepositoryUrl")
+        logger.log(logLevel, "Develocity plugins resolution: $pluginRepositoryUrl")
 
         repositories {
             maven {
                 url = pluginRepositoryUrl
                 if (pluginRepositoryUsername && pluginRepositoryPassword) {
-                    logger.lifecycle("Using credentials for plugin repository")
+                    logger.log(logLevel, "Using credentials for plugin repository")
                     credentials {
                         username = pluginRepositoryUsername
                         password = pluginRepositoryPassword
@@ -90,10 +91,11 @@ if (!isTopLevelBuild) {
     return
 }
 
+def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
 def initScriptName = buildscript.sourceFile.name
 if (requestedInitScriptName != initScriptName) {
-    logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
+    logger.log(logLevel, "Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
     return
 }
 
@@ -132,6 +134,7 @@ void enableDevelocityInjection() {
     def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity.terms-of-use.url')
     def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity.terms-of-use.agree')
     def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity.auto-injection.custom-value')
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -145,22 +148,22 @@ void enableDevelocityInjection() {
     }
 
     def printEnforcingDevelocityUrl = {
-        logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+        logger.log(logLevel, "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
     }
 
     def printAcceptingGradleTermsOfUse = {
-        logger.lifecycle("Accepting Gradle Terms of Use: $buildScanTermsOfUseUrl")
+        logger.log(logLevel, "Accepting Gradle Terms of Use: $buildScanTermsOfUseUrl")
     }
 
     // finish early if DV plugin version is unsupported (v3.6.4 is the minimum version tested and supports back to DV 2021.1)
     if (develocityPluginVersion && isNotAtLeast(develocityPluginVersion, '3.6.4')) {
-        logger.warn("Develocity Gradle plugin must be at least 3.6.4. Configured version is $develocityPluginVersion.")
+        logger.log(LogLevel.WARN, "Develocity Gradle plugin must be at least 3.6.4. Configured version is $develocityPluginVersion.")
         return
     }
 
     // finish early if configuration parameters passed in via system properties are not valid/supported
     if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
-        logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+        logger.log(LogLevel.WARN, "Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
         return
     }
 
@@ -187,7 +190,7 @@ void enableDevelocityInjection() {
                             { rootExtension }
                         )
                         if (develocityUrl) {
-                            logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            logger.log(logLevel, "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                             rootExtension.server = develocityUrl
                             rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
                         }
@@ -197,7 +200,7 @@ void enableDevelocityInjection() {
                         }
                         buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                         if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
-                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            logger.log(logLevel, "Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                             if (isAtLeast(develocityPluginVersion, '3.17')) {
                                 buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
                             } else if (isAtLeast(develocityPluginVersion, '3.7')) {
@@ -225,7 +228,7 @@ void enableDevelocityInjection() {
                             develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                         }
 
-                        logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                        logger.log(logLevel, "Setting uploadInBackground: $buildScanUploadInBackground")
                         develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                     },
                     { buildScan ->
@@ -250,7 +253,7 @@ void enableDevelocityInjection() {
 
                         // uploadInBackground available for build-scan-plugin 3.3.4 and later only
                         if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) {
-                            logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                            logger.log(logLevel, "Setting uploadInBackground: $buildScanUploadInBackground")
                             buildScan.uploadInBackground = buildScanUploadInBackground
                         }
                     }
@@ -261,7 +264,7 @@ void enableDevelocityInjection() {
                         it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
                     }
                     if (!ccudPluginComponent) {
-                        logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
+                        logger.log(logLevel, "Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
                         pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                     }
                 }
@@ -274,7 +277,7 @@ void enableDevelocityInjection() {
                     def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                     applyPluginExternally(settings.pluginManager, pluginClass, develocityPluginVersion)
                     if (develocityUrl) {
-                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        logger.log(logLevel, "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                         eachDevelocitySettingsExtension(settings) { ext ->
                             // server and allowUntrustedServer must be configured via buildScan extension for gradle-enterprise-plugin 3.1.1 and earlier
                             if (ext.metaClass.respondsTo(ext, 'getServer')) {
@@ -293,13 +296,13 @@ void enableDevelocityInjection() {
 
                     eachDevelocitySettingsExtension(settings,
                         { develocity ->
-                            logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                            logger.log(logLevel, "Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                             develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
                         },
                         { gradleEnterprise ->
                             gradleEnterprise.buildScan.publishAlways()
                             if (isAtLeast(develocityPluginVersion, '2.1')) {
-                                logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                                logger.log(logLevel, "Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                                 if (isAtLeast(develocityPluginVersion, '3.7')) {
                                     gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
                                 } else {
@@ -325,7 +328,7 @@ void enableDevelocityInjection() {
                         develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                     }
 
-                    logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                    logger.log(logLevel, "Setting uploadInBackground: $buildScanUploadInBackground")
                     develocity.buildScan.uploadInBackground = buildScanUploadInBackground
                 },
                 { gradleEnterprise ->
@@ -349,7 +352,7 @@ void enableDevelocityInjection() {
 
                     // uploadInBackground available for gradle-enterprise-plugin 3.3.4 and later only
                     if (gradleEnterprise.buildScan.metaClass.respondsTo(gradleEnterprise.buildScan, 'setUploadInBackground', Boolean)) {
-                        logger.lifecycle("Setting uploadInBackground: $buildScanUploadInBackground")
+                        logger.log(logLevel, "Setting uploadInBackground: $buildScanUploadInBackground")
                         gradleEnterprise.buildScan.uploadInBackground = buildScanUploadInBackground
                     }
                 }
@@ -357,7 +360,7 @@ void enableDevelocityInjection() {
 
             if (ccudPluginVersion) {
                 if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                    logger.lifecycle("Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
+                    logger.log(logLevel, "Applying $CCUD_PLUGIN_CLASS with version $ccudPluginVersion via init script")
                     settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
                 }
             }
@@ -366,7 +369,8 @@ void enableDevelocityInjection() {
 }
 
 void applyPluginExternally(def pluginManager, String pluginClassName, String pluginVersion) {
-    logger.lifecycle("Applying $pluginClassName with version $pluginVersion via init script")
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
+    logger.log(logLevel, "Applying $pluginClassName with version $pluginVersion via init script")
 
     def externallyApplied = 'develocity.externally-applied'
     def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -218,6 +218,10 @@ abstract class BaseInitScriptTest extends Specification {
         assertNoStackTraces(result)
     }
 
+    BuildResult run(TestGradleVersion testGradle, DvInjectionTestConfig config, List<String> args = ["help"]) {
+        return run(args, testGradle, config.envVars)
+    }
+
     GradleRunner createRunner(List<String> args, GradleVersion gradleVersion = GradleVersion.current(), Map<String, String> envVars = [:]) {
         args << '-I' << initScriptFile.absolutePath
 
@@ -235,6 +239,10 @@ abstract class BaseInitScriptTest extends Specification {
         runner
     }
 
+    DvInjectionTestConfig testConfig(String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
+        new DvInjectionTestConfig(mockScansServer.address, develocityPluginVersion.toString())
+    }
+
     private boolean testKitSupportsEnvVars(GradleVersion gradleVersion) {
         // TestKit supports env vars for Gradle 3.5+, except on M1 Mac where only 6.9+ is supported
         def isM1Mac = System.getProperty("os.arch") == "aarch64"
@@ -250,6 +258,7 @@ abstract class BaseInitScriptTest extends Specification {
         def mapping = [
             DEVELOCITY_INJECTION_ENABLED              : "develocity.injection-enabled",
             DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity.injection.init-script-name",
+            DEVELOCITY_INJECTION_DEBUG                : "develocity.injection.debug",
             DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE    : "develocity.auto-injection.custom-value",
             DEVELOCITY_URL                            : "develocity.url",
             DEVELOCITY_ALLOW_UNTRUSTED_SERVER         : "develocity.allow-untrusted-server",
@@ -282,6 +291,203 @@ abstract class BaseInitScriptTest extends Specification {
     BuildResult assertNoStackTraces(BuildResult result) {
         assert !result.output.contains("Exception:")
         return result
+    }
+
+    void outputContainsBuildScanUrl(BuildResult result) {
+        def message = "Publishing build scan..."
+        def buildScanUrl = "${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID"
+        assert result.output.contains(message)
+        assert result.output.contains(buildScanUrl)
+        assert 1 == result.output.count(message)
+        assert 1 == result.output.count(buildScanUrl)
+        assert result.output.indexOf(message) < result.output.indexOf(buildScanUrl)
+    }
+
+    void outputContainsDevelocityPluginApplicationViaInitScript(BuildResult result, GradleVersion gradleVersion, String pluginVersion = DEVELOCITY_PLUGIN_VERSION) {
+        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin with version 1.16 via init script"
+        def pluginApplicationLogMsgBuildScanPlugin = "Applying com.gradle.scan.plugin.BuildScanPlugin with version ${pluginVersion} via init script"
+        def pluginApplicationLogMsgGEPlugin = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin with version ${pluginVersion} via init script"
+        def pluginApplicationLogMsgDVPlugin = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin with version ${pluginVersion} via init script"
+
+        def isGEPluginVersion = GradleVersion.version(pluginVersion) < GradleVersion.version("3.17")
+
+        if (gradleVersion < GRADLE_5) {
+            assert result.output.contains(pluginApplicationLogMsgGradle4)
+            assert 1 == result.output.count(pluginApplicationLogMsgGradle4)
+            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
+        } else if (gradleVersion < GRADLE_6 && isGEPluginVersion) {
+            assert result.output.contains(pluginApplicationLogMsgBuildScanPlugin)
+            assert 1 == result.output.count(pluginApplicationLogMsgBuildScanPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
+        } else if (isGEPluginVersion) {
+            assert result.output.contains(pluginApplicationLogMsgGEPlugin)
+            assert 1 == result.output.count(pluginApplicationLogMsgGEPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgGradle4)
+            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
+        } else {
+            assert result.output.contains(pluginApplicationLogMsgDVPlugin)
+            assert 1 == result.output.count(pluginApplicationLogMsgDVPlugin)
+            assert !result.output.contains(pluginApplicationLogMsgGradle4)
+            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
+        }
+    }
+
+    void outputMissesDevelocityPluginApplicationViaInitScript(BuildResult result) {
+        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin"
+        def pluginApplicationLogMsgGradle5AndHigher = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin"
+        assert !result.output.contains(pluginApplicationLogMsgGradle4)
+        assert !result.output.contains(pluginApplicationLogMsgGradle5AndHigher)
+    }
+
+    void outputContainsCcudPluginApplicationViaInitScript(BuildResult result, String ccudPluginVersion = CCUD_PLUGIN_VERSION) {
+        def pluginApplicationLogMsg = "Applying com.gradle.CommonCustomUserDataGradlePlugin with version ${ccudPluginVersion} via init script"
+        assert result.output.contains(pluginApplicationLogMsg)
+        assert 1 == result.output.count(pluginApplicationLogMsg)
+    }
+
+    void outputMissesCcudPluginApplicationViaInitScript(BuildResult result) {
+        def pluginApplicationLogMsg = "Applying com.gradle.CommonCustomUserDataGradlePlugin"
+        assert !result.output.contains(pluginApplicationLogMsg)
+    }
+
+    void outputContainsDevelocityConnectionInfo(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
+        def develocityConnectionInfo = "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
+        assert result.output.contains(develocityConnectionInfo)
+        assert 1 == result.output.count(develocityConnectionInfo)
+    }
+
+    void outputCaptureFileFingerprints(BuildResult result, boolean captureFileFingerprints) {
+        def captureFileFingerprintsInfo = "Setting captureFileFingerprints: $captureFileFingerprints"
+        assert result.output.contains(captureFileFingerprintsInfo)
+        assert 1 == result.output.count(captureFileFingerprintsInfo)
+    }
+
+    void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl, boolean withCredentials = false) {
+        def repositoryInfo = "Develocity plugins resolution: ${gradlePluginRepositoryUrl}"
+        assert result.output.contains(repositoryInfo)
+        assert 1 == result.output.count(repositoryInfo)
+
+        if (withCredentials) {
+            def credentialsInfo = "Using credentials for plugin repository"
+            assert result.output.contains(credentialsInfo)
+            assert 1 == result.output.count(credentialsInfo)
+        }
+    }
+
+    void outputEnforcesDevelocityUrl(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
+        def enforceUrl = "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
+        assert result.output.contains(enforceUrl)
+        assert 1 == result.output.count(enforceUrl)
+    }
+
+    void outputContainsAcceptingGradleTermsOfUse(BuildResult result) {
+        def message = "Accepting Gradle Terms of Use: https://gradle.com/help/legal-terms-of-use"
+        assert result.output.contains(message)
+        assert 1 == result.output.count(message)
+    }
+
+    void outputContainsUploadInBackground(BuildResult result, boolean uploadInBackground) {
+        def message = "Setting uploadInBackground: $uploadInBackground"
+        assert result.output.contains(message)
+        assert 1 == result.output.count(message)
+    }
+
+    void outputMissesUploadInBackground(BuildResult result) {
+        def message = "Setting uploadInBackground:"
+        assert !result.output.contains(message)
+        assert 0 == result.output.count(message)
+    }
+
+    static class DvInjectionTestConfig {
+        String serverUrl
+        boolean enforceUrl = false
+        String develocityPluginVersion = null
+        String ccudPluginVersion = null
+        String pluginRepositoryUrl = null
+        String pluginRepositoryUsername = null
+        String pluginRepositoryPassword = null
+        boolean captureFileFingerprints = false
+        String termsOfUseUrl = null
+        String termsOfUseAgree = null
+        boolean uploadInBackground = true // Need to upload in background since our Mock server doesn't cope with foreground upload
+        boolean debug = true
+
+        DvInjectionTestConfig(URI serverAddress, String develocityPluginVersion) {
+            this.serverUrl = serverAddress.toString()
+            this.develocityPluginVersion = develocityPluginVersion
+        }
+
+        DvInjectionTestConfig withoutDevelocityPluginVersion() {
+            develocityPluginVersion = null
+            return this
+        }
+
+        DvInjectionTestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
+            ccudPluginVersion = version
+            return this
+        }
+
+        DvInjectionTestConfig withServer(URI url, boolean enforceUrl = false) {
+            serverUrl = url.toASCIIString()
+            this.enforceUrl = enforceUrl
+            return this
+        }
+
+        DvInjectionTestConfig withPluginRepository(URI pluginRepositoryUrl) {
+            this.pluginRepositoryUrl = pluginRepositoryUrl
+            return this
+        }
+
+        DvInjectionTestConfig withCaptureFileFingerprints() {
+            this.captureFileFingerprints = true
+            return this
+        }
+
+        DvInjectionTestConfig withPluginRepositoryCredentials(String pluginRepoUsername, String pluginRepoPassword) {
+            this.pluginRepositoryUsername = pluginRepoUsername
+            this.pluginRepositoryPassword = pluginRepoPassword
+            return this
+        }
+
+        DvInjectionTestConfig withAcceptGradleTermsOfUse() {
+            this.termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+            this.termsOfUseAgree = "yes"
+            return this
+        }
+
+        DvInjectionTestConfig withUploadInBackground(boolean uploadInBackground) {
+            this.uploadInBackground = uploadInBackground
+            return this
+        }
+
+        DvInjectionTestConfig withDebug(boolean debug) {
+            this.debug = debug
+            return this
+        }
+
+        Map<String, String> getEnvVars() {
+            Map<String, String> envVars = [
+                DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity-injection.init.gradle",
+                DEVELOCITY_INJECTION_ENABLED              : "true",
+                DEVELOCITY_INJECTION_DEBUG                : String.valueOf(debug),
+                DEVELOCITY_URL                            : serverUrl,
+                DEVELOCITY_ALLOW_UNTRUSTED_SERVER         : "true",
+                DEVELOCITY_BUILD_SCAN_UPLOAD_IN_BACKGROUND: String.valueOf(uploadInBackground),
+                DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE    : 'gradle-actions'
+            ]
+            if (enforceUrl) envVars.put("DEVELOCITY_ENFORCE_URL", "true")
+            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_PLUGIN_VERSION", develocityPluginVersion)
+            if (ccudPluginVersion != null) envVars.put("DEVELOCITY_CCUD_PLUGIN_VERSION", ccudPluginVersion)
+            if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
+            if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
+            if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
+            if (captureFileFingerprints) envVars.put("DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true")
+            if (termsOfUseUrl != null) envVars.put("DEVELOCITY_TERMS_OF_USE_URL", termsOfUseUrl)
+            if (termsOfUseAgree != null) envVars.put("DEVELOCITY_TERMS_OF_USE_AGREE", termsOfUseAgree)
+            return envVars
+        }
     }
 
     static final class TestGradleVersion {

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -26,7 +26,7 @@ class TestBuildScanCapture extends BaseInitScriptTest {
         captureBuildScanLinks()
 
         when:
-        def config = TestDevelocityInjection.createTestConfig(mockScansServer.address, testDvPlugin.version)
+        def config = testConfig(testDvPlugin.version)
         def result = run(['help'], testGradle, config.envVars)
 
         then:

--- a/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
+++ b/src/test/groovy/com/gradle/TestBuildScanCapture.groovy
@@ -6,6 +6,22 @@ import spock.lang.Requires
 class TestBuildScanCapture extends BaseInitScriptTest {
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})
+    def "does not capture build scan url when init script name doesn't match and capture is enabled"() {
+        given:
+        captureBuildScanLinks()
+
+        when:
+        def result = run(testGradle, testConfig().withInjectionEnabled(false).withInitScriptName("foo.gradle"))
+
+        then:
+        result.output.contains("Build Scan capture not enabled because requested init script name was 'foo.gradle', but 'develocity-injection.init.gradle' was expected")
+        buildScanUrlIsNotCaptured(result)
+
+        where:
+        testGradle << ALL_GRADLE_VERSIONS
+    }
+
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not capture build scan url when init-script not enabled"() {
         given:
         captureBuildScanLinks()

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -1,7 +1,5 @@
 package com.gradle
 
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.util.GradleVersion
 import spock.lang.Requires
 
 class TestDevelocityInjection extends BaseInitScriptTest {
@@ -90,7 +88,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
-            // Ignore test for old versions of plugin where no CCUD works.
+        // Ignore test for old versions of plugin where no CCUD works.
             .findAll {testGradle, testDvPlugin -> testDvPlugin.compatibleCCUDVersion != null}
     }
 
@@ -111,7 +109,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         where:
         [testGradle, testDvPlugin] << getVersionsToTestForExistingDvPlugin(CCUD_COMPATIBLE_GRADLE_VERSIONS)
-            // Ignore test for old versions of plugin where no CCUD works.
+        // Ignore test for old versions of plugin where no CCUD works.
             .findAll {testGradle, testDvPlugin -> testDvPlugin.compatibleCCUDVersion != null}
     }
 
@@ -432,205 +430,4 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         testGradle << CONFIGURATION_CACHE_GRADLE_VERSIONS
     }
 
-    void outputContainsBuildScanUrl(BuildResult result) {
-        def message = "Publishing build scan..."
-        def buildScanUrl = "${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID"
-        assert result.output.contains(message)
-        assert result.output.contains(buildScanUrl)
-        assert 1 == result.output.count(message)
-        assert 1 == result.output.count(buildScanUrl)
-        assert result.output.indexOf(message) < result.output.indexOf(buildScanUrl)
-    }
-
-    void outputContainsDevelocityPluginApplicationViaInitScript(BuildResult result, GradleVersion gradleVersion, String pluginVersion = DEVELOCITY_PLUGIN_VERSION) {
-        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin with version 1.16 via init script"
-        def pluginApplicationLogMsgBuildScanPlugin = "Applying com.gradle.scan.plugin.BuildScanPlugin with version ${pluginVersion} via init script"
-        def pluginApplicationLogMsgGEPlugin = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin with version ${pluginVersion} via init script"
-        def pluginApplicationLogMsgDVPlugin = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin with version ${pluginVersion} via init script"
-
-        def isGEPluginVersion = GradleVersion.version(pluginVersion) < GradleVersion.version("3.17")
-
-        if (gradleVersion < GRADLE_5) {
-            assert result.output.contains(pluginApplicationLogMsgGradle4)
-            assert 1 == result.output.count(pluginApplicationLogMsgGradle4)
-            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
-            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
-        } else if (gradleVersion < GRADLE_6 && isGEPluginVersion) {
-            assert result.output.contains(pluginApplicationLogMsgBuildScanPlugin)
-            assert 1 == result.output.count(pluginApplicationLogMsgBuildScanPlugin)
-            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
-            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
-        } else if (isGEPluginVersion) {
-            assert result.output.contains(pluginApplicationLogMsgGEPlugin)
-            assert 1 == result.output.count(pluginApplicationLogMsgGEPlugin)
-            assert !result.output.contains(pluginApplicationLogMsgGradle4)
-            assert !result.output.contains(pluginApplicationLogMsgDVPlugin)
-        } else {
-            assert result.output.contains(pluginApplicationLogMsgDVPlugin)
-            assert 1 == result.output.count(pluginApplicationLogMsgDVPlugin)
-            assert !result.output.contains(pluginApplicationLogMsgGradle4)
-            assert !result.output.contains(pluginApplicationLogMsgGEPlugin)
-        }
-    }
-
-    void outputMissesDevelocityPluginApplicationViaInitScript(BuildResult result) {
-        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin"
-        def pluginApplicationLogMsgGradle5AndHigher = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin"
-        assert !result.output.contains(pluginApplicationLogMsgGradle4)
-        assert !result.output.contains(pluginApplicationLogMsgGradle5AndHigher)
-    }
-
-    void outputContainsCcudPluginApplicationViaInitScript(BuildResult result, String ccudPluginVersion = CCUD_PLUGIN_VERSION) {
-        def pluginApplicationLogMsg = "Applying com.gradle.CommonCustomUserDataGradlePlugin with version ${ccudPluginVersion} via init script"
-        assert result.output.contains(pluginApplicationLogMsg)
-        assert 1 == result.output.count(pluginApplicationLogMsg)
-    }
-
-    void outputMissesCcudPluginApplicationViaInitScript(BuildResult result) {
-        def pluginApplicationLogMsg = "Applying com.gradle.CommonCustomUserDataGradlePlugin"
-        assert !result.output.contains(pluginApplicationLogMsg)
-    }
-
-    void outputContainsDevelocityConnectionInfo(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
-        def develocityConnectionInfo = "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
-        assert result.output.contains(develocityConnectionInfo)
-        assert 1 == result.output.count(develocityConnectionInfo)
-    }
-
-    void outputCaptureFileFingerprints(BuildResult result, boolean captureFileFingerprints) {
-        def captureFileFingerprintsInfo = "Setting captureFileFingerprints: $captureFileFingerprints"
-        assert result.output.contains(captureFileFingerprintsInfo)
-        assert 1 == result.output.count(captureFileFingerprintsInfo)
-    }
-
-    void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl, boolean withCredentials = false) {
-        def repositoryInfo = "Develocity plugins resolution: ${gradlePluginRepositoryUrl}"
-        assert result.output.contains(repositoryInfo)
-        assert 1 == result.output.count(repositoryInfo)
-
-        if (withCredentials) {
-            def credentialsInfo = "Using credentials for plugin repository"
-            assert result.output.contains(credentialsInfo)
-            assert 1 == result.output.count(credentialsInfo)
-        }
-    }
-
-    void outputEnforcesDevelocityUrl(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
-        def enforceUrl = "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
-        assert result.output.contains(enforceUrl)
-        assert 1 == result.output.count(enforceUrl)
-    }
-
-    void outputContainsAcceptingGradleTermsOfUse(BuildResult result) {
-        def message = "Accepting Gradle Terms of Use: https://gradle.com/help/legal-terms-of-use"
-        assert result.output.contains(message)
-        assert 1 == result.output.count(message)
-    }
-
-    void outputContainsUploadInBackground(BuildResult result, boolean uploadInBackground) {
-        def message = "Setting uploadInBackground: $uploadInBackground"
-        assert result.output.contains(message)
-        assert 1 == result.output.count(message)
-    }
-
-    void outputMissesUploadInBackground(BuildResult result) {
-        def message = "Setting uploadInBackground:"
-        assert !result.output.contains(message)
-        assert 0 == result.output.count(message)
-    }
-
-    private BuildResult run(TestGradleVersion testGradle, DvInjectionTestConfig config, List<String> args = ["help"]) {
-        return run(args, testGradle, config.envVars)
-    }
-
-    DvInjectionTestConfig testConfig(String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
-        createTestConfig(mockScansServer.address, develocityPluginVersion)
-    }
-
-    static DvInjectionTestConfig createTestConfig(URI serverAddress, String develocityPluginVersion = DEVELOCITY_PLUGIN_VERSION) {
-        new DvInjectionTestConfig(serverAddress, develocityPluginVersion.toString())
-    }
-
-    static class DvInjectionTestConfig {
-        String serverUrl
-        boolean enforceUrl = false
-        String develocityPluginVersion = null
-        String ccudPluginVersion = null
-        String pluginRepositoryUrl = null
-        String pluginRepositoryUsername = null
-        String pluginRepositoryPassword = null
-        boolean captureFileFingerprints = false
-        String termsOfUseUrl = null
-        String termsOfUseAgree = null
-        boolean uploadInBackground = true // Need to upload in background since our Mock server doesn't cope with foreground upload
-
-        DvInjectionTestConfig(URI serverAddress, String develocityPluginVersion) {
-            this.serverUrl = serverAddress.toString()
-            this.develocityPluginVersion = develocityPluginVersion
-        }
-
-        DvInjectionTestConfig withoutDevelocityPluginVersion() {
-            develocityPluginVersion = null
-            return this
-        }
-
-        DvInjectionTestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
-            ccudPluginVersion = version
-            return this
-        }
-
-        DvInjectionTestConfig withServer(URI url, boolean enforceUrl = false) {
-            serverUrl = url.toASCIIString()
-            this.enforceUrl = enforceUrl
-            return this
-        }
-
-        DvInjectionTestConfig withPluginRepository(URI pluginRepositoryUrl) {
-            this.pluginRepositoryUrl = pluginRepositoryUrl
-            return this
-        }
-
-        DvInjectionTestConfig withCaptureFileFingerprints() {
-            this.captureFileFingerprints = true
-            return this
-        }
-
-        DvInjectionTestConfig withPluginRepositoryCredentials(String pluginRepoUsername, String pluginRepoPassword) {
-            this.pluginRepositoryUsername = pluginRepoUsername
-            this.pluginRepositoryPassword = pluginRepoPassword
-            return this
-        }
-
-        DvInjectionTestConfig withAcceptGradleTermsOfUse() {
-            this.termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-            this.termsOfUseAgree = "yes"
-            return this
-        }
-
-        DvInjectionTestConfig withUploadInBackground(boolean uploadInBackground) {
-            this.uploadInBackground = uploadInBackground
-            return this
-        }
-
-        Map<String, String> getEnvVars() {
-            Map<String, String> envVars = [
-                DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity-injection.init.gradle",
-                DEVELOCITY_INJECTION_ENABLED              : "true",
-                DEVELOCITY_URL                            : serverUrl,
-                DEVELOCITY_ALLOW_UNTRUSTED_SERVER         : "true",
-                DEVELOCITY_BUILD_SCAN_UPLOAD_IN_BACKGROUND: String.valueOf(uploadInBackground),
-                DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE    : 'gradle-actions'
-            ]
-            if (enforceUrl) envVars.put("DEVELOCITY_ENFORCE_URL", "true")
-            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_PLUGIN_VERSION", develocityPluginVersion)
-            if (ccudPluginVersion != null) envVars.put("DEVELOCITY_CCUD_PLUGIN_VERSION", ccudPluginVersion)
-            if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
-            if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
-            if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
-            if (captureFileFingerprints) envVars.put("DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true")
-            if (termsOfUseUrl != null) envVars.put("DEVELOCITY_TERMS_OF_USE_URL", termsOfUseUrl)
-            if (termsOfUseAgree != null) envVars.put("DEVELOCITY_TERMS_OF_USE_AGREE", termsOfUseAgree)
-            return envVars
-        }
-    }
 }

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -6,6 +6,23 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     static final List<TestGradleVersion> CCUD_COMPATIBLE_GRADLE_VERSIONS = ALL_GRADLE_VERSIONS - [GRADLE_3_X]
 
     @Requires({data.testGradle.compatibleWithCurrentJvm})
+    def "does not inject when init script name doesn't match and injection is enabled"() {
+        when:
+        def result = run(testGradle, testConfig().withInjectionEnabled(true).withInitScriptName("foo.gradle").withCCUDPlugin())
+
+        then:
+        result.output.contains("Develocity injection not enabled because requested init script name was 'foo.gradle', but 'develocity-injection.init.gradle' was expected")
+
+        and:
+        outputMissesDevelocityPluginApplicationViaInitScript(result)
+        outputMissesCcudPluginApplicationViaInitScript(result)
+        outputMissesBuildScanUrl(result)
+
+        where:
+        testGradle << ALL_GRADLE_VERSIONS
+    }
+
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
     def "does not apply Develocity plugins when not requested"() {
         when:
         def result = run([], testGradle)

--- a/src/test/groovy/com/gradle/TestInitScriptMetaOptions.groovy
+++ b/src/test/groovy/com/gradle/TestInitScriptMetaOptions.groovy
@@ -1,0 +1,23 @@
+package com.gradle
+
+import spock.lang.Requires
+
+class TestInitScriptMetaOptions extends BaseInitScriptTest {
+
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
+    def "does not log debug messages when debug disabled"() {
+        when:
+        def result = run(testGradle, testConfig().withDebug(false).withCCUDPlugin())
+
+        then:
+        outputMissesDevelocityPluginApplicationViaInitScript(result)
+        outputMissesCcudPluginApplicationViaInitScript(result)
+
+        and:
+        outputContainsBuildScanUrl(result)
+
+        where:
+        testGradle << ALL_GRADLE_VERSIONS
+    }
+
+}


### PR DESCRIPTION
The logging done by the init script is mainly used for testing purposes and not needed by consumers.

In cases where this additional logging is needed, e.g., for debugging injection in an environment, the property `develocity.injection.debug=true` can be used to enable it.