### PR TITLE
Prefix all inputs with 'develocity-injection'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ or via environment variables by replacing all hyphens (`-`) and periods (`.`) wi
 
 ### Develocity plugin resolution
 
-| Input                                    |      Required      | Definition                                                                                                                                   |
-|------------------------------------------|:------------------:|----------------------------------------------------------------------------------------------------------------------------------------------|
-| develocity-injection.plugin-version      | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
-| develocity-injection.ccud-plugin-version |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
-| gradle.plugin-repository.url             |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
-| gradle.plugin-repository.username        |                    | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
-| gradle.plugin-repository.password        |                    | the password for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+| Input                                           |      Required      | Definition                                                                                                                                   |
+|-------------------------------------------------|:------------------:|----------------------------------------------------------------------------------------------------------------------------------------------|
+| develocity-injection.develocity-plugin.version  | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
+| develocity-injection.ccud-plugin.version        |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
+| develocity-injection.plugin-repository.url      |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
+| develocity-injection.plugin-repository.username |                    | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+| develocity-injection.plugin-repository.password |                    | the password for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
 
 ### Develocity configuration
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ or via environment variables by replacing all hyphens (`-`) and periods (`.`) wi
 
 ### Control parameters
 
-| Input                                 | Required           | Definition                                                     |
-|---------------------------------------|--------------------|----------------------------------------------------------------|
+| Input                                 |      Required      | Definition                                                     |
+|---------------------------------------|:------------------:|----------------------------------------------------------------|
 | develocity-injection.init-script-name | :white_check_mark: | must match the name of the init-script                         |
 | develocity-injection.enabled          | :white_check_mark: | set to 'true' to enable Develocity injection                   |
 | develocity-injection.debug            |                    | set to 'true' to enable debug logging for Develocity injection |
 
 ### Develocity plugin resolution
 
-| Input                                    | Required           | Definition                                                                                                                                   |
-|------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| Input                                    |      Required      | Definition                                                                                                                                   |
+|------------------------------------------|:------------------:|----------------------------------------------------------------------------------------------------------------------------------------------|
 | develocity-injection.plugin-version      | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
 | develocity-injection.ccud-plugin-version |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
 | gradle.plugin-repository.url             |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
@@ -45,8 +45,8 @@ or via environment variables by replacing all hyphens (`-`) and periods (`.`) wi
 
 ### Develocity configuration
 
-| Input                                          | Required           | Definition                                                                                                                 |
-|------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Input                                          |      Required      | Definition                                                                                                                 |
+|------------------------------------------------|:------------------:|----------------------------------------------------------------------------------------------------------------------------|
 | develocity-injection.url                       | :white_check_mark: | the URL of the Develocity server                                                                                           |
 | develocity-injection.enforce-url               |                    | enforce the configured Develocity URL over a URL configured in the project's build                                         |
 | develocity-injection.allow-untrusted-server    |                    | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,45 @@ An init-script that can be used by CI integrations to inject Develocity into a G
   - Tag the repository with the version number
   - Commit the new reference script to this repository
   - [Create PRs to update the script](https://github.com/gradle/develocity-ci-injection/actions/runs/9102707566/workflow#L48-L57) in various CI plugin repositories. [See here for an example run](https://github.com/gradle/develocity-ci-injection/actions/runs/9102707566) with links to generated PRs.
- 
+
+## Develocity injection input parameters
+
+A number of input parameters can be used to control Develocity injection.
+
+These inputs can be provided via System Properties (eg `-Ddevelocity-injection.url=https://ge.gradle.org`)
+or via Environment variables in all caps (eg `DEVELOCITY_INJECTION_URL=https://ge.gradle.org`)
+
+### Control parameters
+
+| Input                                                                          | Required           | Definition                                                     |
+|--------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------|
+| develocity-injection.init-script-name<br>DEVELOCITY_INJECTION_INIT_SCRIPT_NAME | :white_check_mark: | must match the name of the init-script                         |
+| develocity-injection.enabled<br>DEVELOCITY_INJECTION_ENABLED                   | :white_check_mark: | set to 'true' to enable Develocity injection                   |
+| develocity-injection.debug<br>DEVELOCITY_INJECTION_DEBUG                       |                    | set to 'true' to enable debug logging for Develocity injection |
+
+### Develocity plugin resolution
+
+| Input                                                                                | Required           | Definition                                                                                                                                   |
+|--------------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| develocity-injection.plugin-version<br>DEVELOCITY_INJECTION_PLUGIN_VERSION           | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
+| develocity-injection.ccud-plugin-version<br>DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
+| gradle.plugin-repository.url<br>GRADLE_PLUGIN_REPOSITORY_URL                         |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
+| gradle.plugin-repository.username<br>GRADLE_PLUGIN_REPOSITORY_USERNAME               |                    | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+| gradle.plugin-repository.password<br>GRADLE_PLUGIN_REPOSITORY_PASSWORD               |                    | the password for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+
+### Develocity configuration
+
+| Input                                                                                            | Required           | Definition                                                                                                                 |
+|--------------------------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------|
+| develocity-injection.url<br>DEVELOCITY_INJECTION_URL                                             | :white_check_mark: | the URL of the Develocity server                                                                                           |
+| develocity-injection.enforce-url<br>DEVELOCITY_INJECTION_ENFORCE_URL                             |                    | enforce the configured Develocity URL over a URL configured in the project's build                                         |
+| develocity-injection.allow-untrusted-server<br>DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER       |                    | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate |
+| develocity-injection.capture-file-fingerprints<br>DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS |                    | enables capturing the paths and content hashes of each individual input file                                               |
+| develocity-injection.upload-in-background<br>DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND           |                    | set to 'false' to disable background upload of build scans                                                                 |
+| develocity-injection.custom-value<br>DEVELOCITY_INJECTION_CUSTOM_VALUE                           |                    | Add a Build Scan custom value to identify auto-injection builds                                                            |
+| develocity-injection.terms-of-use.url<br>DEVELOCITY_INJECTION_TERMS_OF_USE_URL                   |                    | enable publishing to scans.gradle.com                                                                                      |
+| develocity-injection.terms-of-use.agree<br>DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE               |                    | enable publishing to scans.gradle.com                                                                                      |
+
 ## Existing Develocity CI integrations
 
 The following Develocity CI integrations leverage the Gradle init-script from this repository.

--- a/README.md
+++ b/README.md
@@ -22,39 +22,39 @@ An init-script that can be used by CI integrations to inject Develocity into a G
 
 A number of input parameters can be used to control Develocity injection.
 
-These inputs can be provided via System Properties (eg `-Ddevelocity-injection.url=https://ge.gradle.org`)
-or via Environment variables in all caps (eg `DEVELOCITY_INJECTION_URL=https://ge.gradle.org`)
+These inputs can be provided via system properties (e.g., `-Ddevelocity-injection.url=https://ge.gradle.org`)
+or via environment variables by replacing all hyphens (`-`) and periods (`.`) with underscores (`_`), and capitalizing all characters (e.g., `DEVELOCITY_INJECTION_URL=https://ge.gradle.org`).
 
 ### Control parameters
 
-| Input                                                                          | Required           | Definition                                                     |
-|--------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------|
-| develocity-injection.init-script-name<br>DEVELOCITY_INJECTION_INIT_SCRIPT_NAME | :white_check_mark: | must match the name of the init-script                         |
-| develocity-injection.enabled<br>DEVELOCITY_INJECTION_ENABLED                   | :white_check_mark: | set to 'true' to enable Develocity injection                   |
-| develocity-injection.debug<br>DEVELOCITY_INJECTION_DEBUG                       |                    | set to 'true' to enable debug logging for Develocity injection |
+| Input                                 | Required           | Definition                                                     |
+|---------------------------------------|--------------------|----------------------------------------------------------------|
+| develocity-injection.init-script-name | :white_check_mark: | must match the name of the init-script                         |
+| develocity-injection.enabled          | :white_check_mark: | set to 'true' to enable Develocity injection                   |
+| develocity-injection.debug            |                    | set to 'true' to enable debug logging for Develocity injection |
 
 ### Develocity plugin resolution
 
-| Input                                                                                | Required           | Definition                                                                                                                                   |
-|--------------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| develocity-injection.plugin-version<br>DEVELOCITY_INJECTION_PLUGIN_VERSION           | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
-| develocity-injection.ccud-plugin-version<br>DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
-| gradle.plugin-repository.url<br>GRADLE_PLUGIN_REPOSITORY_URL                         |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
-| gradle.plugin-repository.username<br>GRADLE_PLUGIN_REPOSITORY_USERNAME               |                    | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
-| gradle.plugin-repository.password<br>GRADLE_PLUGIN_REPOSITORY_PASSWORD               |                    | the password for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+| Input                                    | Required           | Definition                                                                                                                                   |
+|------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| develocity-injection.plugin-version      | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/develocity/gradle-plugin/) to apply                                    |
+| develocity-injection.ccud-plugin-version |                    | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
+| gradle.plugin-repository.url             |                    | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                 |
+| gradle.plugin-repository.username        |                    | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
+| gradle.plugin-repository.password        |                    | the password for the repository URL to use when resolving the Develocity and CCUD plugins                                                    |
 
 ### Develocity configuration
 
-| Input                                                                                            | Required           | Definition                                                                                                                 |
-|--------------------------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------|
-| develocity-injection.url<br>DEVELOCITY_INJECTION_URL                                             | :white_check_mark: | the URL of the Develocity server                                                                                           |
-| develocity-injection.enforce-url<br>DEVELOCITY_INJECTION_ENFORCE_URL                             |                    | enforce the configured Develocity URL over a URL configured in the project's build                                         |
-| develocity-injection.allow-untrusted-server<br>DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER       |                    | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate |
-| develocity-injection.capture-file-fingerprints<br>DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS |                    | enables capturing the paths and content hashes of each individual input file                                               |
-| develocity-injection.upload-in-background<br>DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND           |                    | set to 'false' to disable background upload of build scans                                                                 |
-| develocity-injection.custom-value<br>DEVELOCITY_INJECTION_CUSTOM_VALUE                           |                    | Add a Build Scan custom value to identify auto-injection builds                                                            |
-| develocity-injection.terms-of-use.url<br>DEVELOCITY_INJECTION_TERMS_OF_USE_URL                   |                    | enable publishing to scans.gradle.com                                                                                      |
-| develocity-injection.terms-of-use.agree<br>DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE               |                    | enable publishing to scans.gradle.com                                                                                      |
+| Input                                          | Required           | Definition                                                                                                                 |
+|------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------|
+| develocity-injection.url                       | :white_check_mark: | the URL of the Develocity server                                                                                           |
+| develocity-injection.enforce-url               |                    | enforce the configured Develocity URL over a URL configured in the project's build                                         |
+| develocity-injection.allow-untrusted-server    |                    | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate |
+| develocity-injection.capture-file-fingerprints |                    | enables capturing the paths and content hashes of each individual input file                                               |
+| develocity-injection.upload-in-background      |                    | set to 'false' to disable background upload of build scans                                                                 |
+| develocity-injection.custom-value              |                    | Add a Build Scan custom value to identify auto-injection builds                                                            |
+| develocity-injection.terms-of-use.url          |                    | enable publishing to scans.gradle.com                                                                                      |
+| develocity-injection.terms-of-use.agree        |                    | enable publishing to scans.gradle.com                                                                                      |
 
 ## Existing Develocity CI integrations
 

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -130,13 +130,13 @@ void enableDevelocityInjection() {
     def develocityUrl = getInputParam(gradle, 'develocity-injection.url')
     def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.allow-untrusted-server'))
     def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.enforce-url'))
-    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.build-scan.upload-in-background'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.upload-in-background'))
     def develocityCaptureFileFingerprints = getInputParam(gradle, 'develocity-injection.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.capture-file-fingerprints')) : true
     def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.plugin.version')
     def ccudPluginVersion = getInputParam(gradle, 'develocity-injection.ccud-plugin.version')
     def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity-injection.terms-of-use.url')
     def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity-injection.terms-of-use.agree')
-    def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity-injection.auto-injection-custom-value')
+    def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity-injection.custom-value')
     def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -123,7 +123,7 @@ void enableDevelocityInjection() {
     def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
     def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
 
-    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME =  'CI auto injection'
+    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
     def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
     def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -30,10 +30,10 @@ initscript {
         return
     }
 
-    def pluginRepositoryUrl = getInputParam(gradle, 'gradle.plugin-repository.url')
-    def pluginRepositoryUsername = getInputParam(gradle, 'gradle.plugin-repository.username')
-    def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
-    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.plugin.version')
+    def pluginRepositoryUrl = getInputParam(gradle, 'develocity-injection.plugin-repository.url')
+    def pluginRepositoryUsername = getInputParam(gradle, 'develocity-injection.plugin-repository.username')
+    def pluginRepositoryPassword = getInputParam(gradle, 'develocity-injection.plugin-repository.password')
+    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.develocity-plugin.version')
     def ccudPluginVersion = getInputParam(gradle, 'develocity-injection.ccud-plugin.version')
     def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
@@ -132,7 +132,7 @@ void enableDevelocityInjection() {
     def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.enforce-url'))
     def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.upload-in-background'))
     def develocityCaptureFileFingerprints = getInputParam(gradle, 'develocity-injection.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.capture-file-fingerprints')) : true
-    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.plugin.version')
+    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.develocity-plugin.version')
     def ccudPluginVersion = getInputParam(gradle, 'develocity-injection.ccud-plugin.version')
     def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity-injection.terms-of-use.url')
     def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity-injection.terms-of-use.agree')

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -375,8 +375,8 @@ void applyPluginExternally(def pluginManager, String pluginClassName, String plu
     def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
     logger.log(logLevel, "Applying $pluginClassName with version $pluginVersion via init script")
 
-    def externallyApplied = 'develocity-injection.develocity.externally-applied'
-    def externallyAppliedDeprecated = 'develocity-injection.gradle-enterprise.externally-applied'
+    def externallyApplied = 'develocity.externally-applied'
+    def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
     def oldValue = System.getProperty(externallyApplied)
     def oldValueDeprecated = System.getProperty(externallyAppliedDeprecated)
     System.setProperty(externallyApplied, 'true')

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -18,14 +18,14 @@ initscript {
         return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
     }
 
-    def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
+    def requestedInitScriptName = getInputParam(gradle, 'develocity-injection.init-script-name')
     def initScriptName = buildscript.sourceFile.name
     if (requestedInitScriptName != initScriptName) {
         return
     }
 
     // Plugin loading is only required for Develocity injection. Abort early if not enabled.
-    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
+    def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity-injection.enabled"))
     if (!develocityInjectionEnabled) {
         return
     }
@@ -33,9 +33,9 @@ initscript {
     def pluginRepositoryUrl = getInputParam(gradle, 'gradle.plugin-repository.url')
     def pluginRepositoryUsername = getInputParam(gradle, 'gradle.plugin-repository.username')
     def pluginRepositoryPassword = getInputParam(gradle, 'gradle.plugin-repository.password')
-    def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
-    def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
-    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
+    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.plugin.version')
+    def ccudPluginVersion = getInputParam(gradle, 'develocity-injection.ccud-plugin.version')
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -91,10 +91,10 @@ if (!isTopLevelBuild) {
     return
 }
 
-def requestedInitScriptName = getInputParam(gradle, 'develocity.injection.init-script-name')
+def requestedInitScriptName = getInputParam(gradle, 'develocity-injection.init-script-name')
 def initScriptName = buildscript.sourceFile.name
 
-def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity.injection-enabled"))
+def develocityInjectionEnabled = Boolean.parseBoolean(getInputParam(gradle, "develocity-injection.enabled"))
 if (develocityInjectionEnabled) {
     if (requestedInitScriptName != initScriptName) {
         logger.log(LogLevel.WARN, "Develocity injection not enabled because requested init script name was '${requestedInitScriptName}', but '${initScriptName}' was expected")
@@ -123,21 +123,21 @@ void enableDevelocityInjection() {
     def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
     def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
 
-    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
+    def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME =  'CI auto injection'
     def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
     def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 
-    def develocityUrl = getInputParam(gradle, 'develocity.url')
-    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity.allow-untrusted-server'))
-    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity.enforce-url'))
-    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity.build-scan.upload-in-background'))
-    def develocityCaptureFileFingerprints = getInputParam(gradle, 'develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam(gradle, 'develocity.capture-file-fingerprints')) : true
-    def develocityPluginVersion = getInputParam(gradle, 'develocity.plugin.version')
-    def ccudPluginVersion = getInputParam(gradle, 'develocity.ccud-plugin.version')
-    def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity.terms-of-use.url')
-    def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity.terms-of-use.agree')
-    def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity.auto-injection.custom-value')
-    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
+    def develocityUrl = getInputParam(gradle, 'develocity-injection.url')
+    def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.allow-untrusted-server'))
+    def develocityEnforceUrl = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.enforce-url'))
+    def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.build-scan.upload-in-background'))
+    def develocityCaptureFileFingerprints = getInputParam(gradle, 'develocity-injection.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.capture-file-fingerprints')) : true
+    def develocityPluginVersion = getInputParam(gradle, 'develocity-injection.plugin.version')
+    def ccudPluginVersion = getInputParam(gradle, 'develocity-injection.ccud-plugin.version')
+    def buildScanTermsOfUseUrl = getInputParam(gradle, 'develocity-injection.terms-of-use.url')
+    def buildScanTermsOfUseAgree = getInputParam(gradle, 'develocity-injection.terms-of-use.agree')
+    def ciAutoInjectionCustomValueValue = getInputParam(gradle, 'develocity-injection.auto-injection-custom-value')
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -372,11 +372,11 @@ void enableDevelocityInjection() {
 }
 
 void applyPluginExternally(def pluginManager, String pluginClassName, String pluginVersion) {
-    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity.injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
+    def logLevel = Boolean.parseBoolean(getInputParam(gradle, 'develocity-injection.debug')) ? LogLevel.LIFECYCLE : LogLevel.INFO
     logger.log(logLevel, "Applying $pluginClassName with version $pluginVersion via init script")
 
-    def externallyApplied = 'develocity.externally-applied'
-    def externallyAppliedDeprecated = 'gradle.enterprise.externally-applied'
+    def externallyApplied = 'develocity-injection.develocity.externally-applied'
+    def externallyAppliedDeprecated = 'develocity-injection.gradle-enterprise.externally-applied'
     def oldValue = System.getProperty(externallyApplied)
     def oldValueDeprecated = System.getProperty(externallyAppliedDeprecated)
     System.setProperty(externallyApplied, 'true')

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -256,22 +256,22 @@ abstract class BaseInitScriptTest extends Specification {
     // for TestKit versions that don't support environment variables, map those vars to system properties
     private static List<String> mapEnvVarsToSystemProps(Map<String, String> envVars) {
         def mapping = [
-            DEVELOCITY_INJECTION_ENABLED                        : "develocity-injection.enabled",
-            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME               : "develocity-injection.init-script-name",
-            DEVELOCITY_INJECTION_DEBUG                          : "develocity-injection.debug",
-            DEVELOCITY_INJECTION_AUTO_INJECTION_CUSTOM_VALUE    : "develocity-injection.auto-injection.custom-value",
-            DEVELOCITY_INJECTION_URL                            : "develocity-injection.url",
-            DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER         : "develocity-injection.allow-untrusted-server",
-            DEVELOCITY_INJECTION_ENFORCE_URL                    : "develocity-injection.enforce-url",
-            DEVELOCITY_INJECTION_PLUGIN_VERSION                 : "develocity-injection.plugin.version",
-            DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION            : "develocity-injection.ccud-plugin.version",
-            DEVELOCITY_INJECTION_BUILD_SCAN_UPLOAD_IN_BACKGROUND: "develocity-injection.build-scan.upload-in-background",
-            DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS      : "develocity-injection.capture-file-fingerprints",
-            DEVELOCITY_INJECTION_TERMS_OF_USE_URL               : "develocity-injection.terms-of-use.url",
-            DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE             : "develocity-injection.terms-of-use.agree",
-            GRADLE_PLUGIN_REPOSITORY_URL                        : "gradle.plugin-repository.url",
-            GRADLE_PLUGIN_REPOSITORY_USERNAME                   : "gradle.plugin-repository.username",
-            GRADLE_PLUGIN_REPOSITORY_PASSWORD                   : "gradle.plugin-repository.password",
+            DEVELOCITY_INJECTION_ENABLED                  : "develocity-injection.enabled",
+            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME         : "develocity-injection.init-script-name",
+            DEVELOCITY_INJECTION_DEBUG                    : "develocity-injection.debug",
+            DEVELOCITY_INJECTION_CUSTOM_VALUE             : "develocity-injection.custom-value",
+            DEVELOCITY_INJECTION_URL                      : "develocity-injection.url",
+            DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER   : "develocity-injection.allow-untrusted-server",
+            DEVELOCITY_INJECTION_ENFORCE_URL              : "develocity-injection.enforce-url",
+            DEVELOCITY_INJECTION_PLUGIN_VERSION           : "develocity-injection.plugin.version",
+            DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION      : "develocity-injection.ccud-plugin.version",
+            DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND     : "develocity-injection.upload-in-background",
+            DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS: "develocity-injection.capture-file-fingerprints",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_URL         : "develocity-injection.terms-of-use.url",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE       : "develocity-injection.terms-of-use.agree",
+            GRADLE_PLUGIN_REPOSITORY_URL                  : "gradle.plugin-repository.url",
+            GRADLE_PLUGIN_REPOSITORY_USERNAME             : "gradle.plugin-repository.username",
+            GRADLE_PLUGIN_REPOSITORY_PASSWORD             : "gradle.plugin-repository.password",
         ]
 
         return envVars.entrySet().stream().map(e -> {

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -487,12 +487,12 @@ abstract class BaseInitScriptTest extends Specification {
 
         Map<String, String> getEnvVars() {
             Map<String, String> envVars = [
-                DEVELOCITY_INJECTION_ENABLED                        : String.valueOf(injectionEnabled),
-                DEVELOCITY_INJECTION_DEBUG                          : String.valueOf(debug),
-                DEVELOCITY_INJECTION_URL                            : serverUrl,
-                DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER         : "true",
-                DEVELOCITY_INJECTION_BUILD_SCAN_UPLOAD_IN_BACKGROUND: String.valueOf(uploadInBackground),
-                DEVELOCITY_INJECTION_AUTO_INJECTION_CUSTOM_VALUE    : 'gradle-actions'
+                DEVELOCITY_INJECTION_ENABLED               : String.valueOf(injectionEnabled),
+                DEVELOCITY_INJECTION_DEBUG                 : String.valueOf(debug),
+                DEVELOCITY_INJECTION_URL                   : serverUrl,
+                DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER: "true",
+                DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND  : String.valueOf(uploadInBackground),
+                DEVELOCITY_INJECTION_CUSTOM_VALUE          : 'gradle-actions'
             ]
             if (initScriptName) envVars.put("DEVELOCITY_INJECTION_INIT_SCRIPT_NAME", initScriptName)
             if (enforceUrl) envVars.put("DEVELOCITY_INJECTION_ENFORCE_URL", "true")

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -256,22 +256,22 @@ abstract class BaseInitScriptTest extends Specification {
     // for TestKit versions that don't support environment variables, map those vars to system properties
     private static List<String> mapEnvVarsToSystemProps(Map<String, String> envVars) {
         def mapping = [
-            DEVELOCITY_INJECTION_ENABLED                  : "develocity-injection.enabled",
-            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME         : "develocity-injection.init-script-name",
-            DEVELOCITY_INJECTION_DEBUG                    : "develocity-injection.debug",
-            DEVELOCITY_INJECTION_CUSTOM_VALUE             : "develocity-injection.custom-value",
-            DEVELOCITY_INJECTION_URL                      : "develocity-injection.url",
-            DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER   : "develocity-injection.allow-untrusted-server",
-            DEVELOCITY_INJECTION_ENFORCE_URL              : "develocity-injection.enforce-url",
-            DEVELOCITY_INJECTION_PLUGIN_VERSION           : "develocity-injection.plugin.version",
-            DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION      : "develocity-injection.ccud-plugin.version",
-            DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND     : "develocity-injection.upload-in-background",
-            DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS: "develocity-injection.capture-file-fingerprints",
-            DEVELOCITY_INJECTION_TERMS_OF_USE_URL         : "develocity-injection.terms-of-use.url",
-            DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE       : "develocity-injection.terms-of-use.agree",
-            GRADLE_PLUGIN_REPOSITORY_URL                  : "gradle.plugin-repository.url",
-            GRADLE_PLUGIN_REPOSITORY_USERNAME             : "gradle.plugin-repository.username",
-            GRADLE_PLUGIN_REPOSITORY_PASSWORD             : "gradle.plugin-repository.password",
+            DEVELOCITY_INJECTION_ENABLED                   : "develocity-injection.enabled",
+            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME          : "develocity-injection.init-script-name",
+            DEVELOCITY_INJECTION_DEBUG                     : "develocity-injection.debug",
+            DEVELOCITY_INJECTION_CUSTOM_VALUE              : "develocity-injection.custom-value",
+            DEVELOCITY_INJECTION_URL                       : "develocity-injection.url",
+            DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER    : "develocity-injection.allow-untrusted-server",
+            DEVELOCITY_INJECTION_ENFORCE_URL               : "develocity-injection.enforce-url",
+            DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION : "develocity-injection.develocity-plugin.version",
+            DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION       : "develocity-injection.ccud-plugin.version",
+            DEVELOCITY_INJECTION_UPLOAD_IN_BACKGROUND      : "develocity-injection.upload-in-background",
+            DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS : "develocity-injection.capture-file-fingerprints",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_URL          : "develocity-injection.terms-of-use.url",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE        : "develocity-injection.terms-of-use.agree",
+            DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_URL     : "develocity-injection.plugin-repository.url",
+            DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_USERNAME: "develocity-injection.plugin-repository.username",
+            DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_PASSWORD: "develocity-injection.plugin-repository.password",
         ]
 
         return envVars.entrySet().stream().map(e -> {
@@ -496,14 +496,14 @@ abstract class BaseInitScriptTest extends Specification {
             ]
             if (initScriptName) envVars.put("DEVELOCITY_INJECTION_INIT_SCRIPT_NAME", initScriptName)
             if (enforceUrl) envVars.put("DEVELOCITY_INJECTION_ENFORCE_URL", "true")
-            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_INJECTION_PLUGIN_VERSION", develocityPluginVersion)
+            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION", develocityPluginVersion)
             if (ccudPluginVersion != null) envVars.put("DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION", ccudPluginVersion)
             if (captureFileFingerprints) envVars.put("DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS", "true")
             if (termsOfUseUrl != null) envVars.put("DEVELOCITY_INJECTION_TERMS_OF_USE_URL", termsOfUseUrl)
             if (termsOfUseAgree != null) envVars.put("DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE", termsOfUseAgree)
-            if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
-            if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
-            if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
+            if (pluginRepositoryUrl != null) envVars.put("DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
+            if (pluginRepositoryUsername != null) envVars.put("DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
+            if (pluginRepositoryPassword != null) envVars.put("DEVELOCITY_INJECTION_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
             return envVars
         }
     }

--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -256,22 +256,22 @@ abstract class BaseInitScriptTest extends Specification {
     // for TestKit versions that don't support environment variables, map those vars to system properties
     private static List<String> mapEnvVarsToSystemProps(Map<String, String> envVars) {
         def mapping = [
-            DEVELOCITY_INJECTION_ENABLED              : "develocity.injection-enabled",
-            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME     : "develocity.injection.init-script-name",
-            DEVELOCITY_INJECTION_DEBUG                : "develocity.injection.debug",
-            DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE    : "develocity.auto-injection.custom-value",
-            DEVELOCITY_URL                            : "develocity.url",
-            DEVELOCITY_ALLOW_UNTRUSTED_SERVER         : "develocity.allow-untrusted-server",
-            DEVELOCITY_ENFORCE_URL                    : "develocity.enforce-url",
-            DEVELOCITY_PLUGIN_VERSION                 : "develocity.plugin.version",
-            DEVELOCITY_CCUD_PLUGIN_VERSION            : "develocity.ccud-plugin.version",
-            DEVELOCITY_BUILD_SCAN_UPLOAD_IN_BACKGROUND: "develocity.build-scan.upload-in-background",
-            DEVELOCITY_CAPTURE_FILE_FINGERPRINTS      : "develocity.capture-file-fingerprints",
-            DEVELOCITY_TERMS_OF_USE_URL               : "develocity.terms-of-use.url",
-            DEVELOCITY_TERMS_OF_USE_AGREE             : "develocity.terms-of-use.agree",
-            GRADLE_PLUGIN_REPOSITORY_URL              : "gradle.plugin-repository.url",
-            GRADLE_PLUGIN_REPOSITORY_USERNAME         : "gradle.plugin-repository.username",
-            GRADLE_PLUGIN_REPOSITORY_PASSWORD         : "gradle.plugin-repository.password",
+            DEVELOCITY_INJECTION_ENABLED                        : "develocity-injection.enabled",
+            DEVELOCITY_INJECTION_INIT_SCRIPT_NAME               : "develocity-injection.init-script-name",
+            DEVELOCITY_INJECTION_DEBUG                          : "develocity-injection.debug",
+            DEVELOCITY_INJECTION_AUTO_INJECTION_CUSTOM_VALUE    : "develocity-injection.auto-injection.custom-value",
+            DEVELOCITY_INJECTION_URL                            : "develocity-injection.url",
+            DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER         : "develocity-injection.allow-untrusted-server",
+            DEVELOCITY_INJECTION_ENFORCE_URL                    : "develocity-injection.enforce-url",
+            DEVELOCITY_INJECTION_PLUGIN_VERSION                 : "develocity-injection.plugin.version",
+            DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION            : "develocity-injection.ccud-plugin.version",
+            DEVELOCITY_INJECTION_BUILD_SCAN_UPLOAD_IN_BACKGROUND: "develocity-injection.build-scan.upload-in-background",
+            DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS      : "develocity-injection.capture-file-fingerprints",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_URL               : "develocity-injection.terms-of-use.url",
+            DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE             : "develocity-injection.terms-of-use.agree",
+            GRADLE_PLUGIN_REPOSITORY_URL                        : "gradle.plugin-repository.url",
+            GRADLE_PLUGIN_REPOSITORY_USERNAME                   : "gradle.plugin-repository.username",
+            GRADLE_PLUGIN_REPOSITORY_PASSWORD                   : "gradle.plugin-repository.password",
         ]
 
         return envVars.entrySet().stream().map(e -> {
@@ -487,23 +487,23 @@ abstract class BaseInitScriptTest extends Specification {
 
         Map<String, String> getEnvVars() {
             Map<String, String> envVars = [
-                DEVELOCITY_INJECTION_ENABLED              : String.valueOf(injectionEnabled),
-                DEVELOCITY_INJECTION_DEBUG                : String.valueOf(debug),
-                DEVELOCITY_URL                            : serverUrl,
-                DEVELOCITY_ALLOW_UNTRUSTED_SERVER         : "true",
-                DEVELOCITY_BUILD_SCAN_UPLOAD_IN_BACKGROUND: String.valueOf(uploadInBackground),
-                DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE    : 'gradle-actions'
+                DEVELOCITY_INJECTION_ENABLED                        : String.valueOf(injectionEnabled),
+                DEVELOCITY_INJECTION_DEBUG                          : String.valueOf(debug),
+                DEVELOCITY_INJECTION_URL                            : serverUrl,
+                DEVELOCITY_INJECTION_ALLOW_UNTRUSTED_SERVER         : "true",
+                DEVELOCITY_INJECTION_BUILD_SCAN_UPLOAD_IN_BACKGROUND: String.valueOf(uploadInBackground),
+                DEVELOCITY_INJECTION_AUTO_INJECTION_CUSTOM_VALUE    : 'gradle-actions'
             ]
             if (initScriptName) envVars.put("DEVELOCITY_INJECTION_INIT_SCRIPT_NAME", initScriptName)
-            if (enforceUrl) envVars.put("DEVELOCITY_ENFORCE_URL", "true")
-            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_PLUGIN_VERSION", develocityPluginVersion)
-            if (ccudPluginVersion != null) envVars.put("DEVELOCITY_CCUD_PLUGIN_VERSION", ccudPluginVersion)
+            if (enforceUrl) envVars.put("DEVELOCITY_INJECTION_ENFORCE_URL", "true")
+            if (develocityPluginVersion != null) envVars.put("DEVELOCITY_INJECTION_PLUGIN_VERSION", develocityPluginVersion)
+            if (ccudPluginVersion != null) envVars.put("DEVELOCITY_INJECTION_CCUD_PLUGIN_VERSION", ccudPluginVersion)
+            if (captureFileFingerprints) envVars.put("DEVELOCITY_INJECTION_CAPTURE_FILE_FINGERPRINTS", "true")
+            if (termsOfUseUrl != null) envVars.put("DEVELOCITY_INJECTION_TERMS_OF_USE_URL", termsOfUseUrl)
+            if (termsOfUseAgree != null) envVars.put("DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE", termsOfUseAgree)
             if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
             if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
             if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
-            if (captureFileFingerprints) envVars.put("DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true")
-            if (termsOfUseUrl != null) envVars.put("DEVELOCITY_TERMS_OF_USE_URL", termsOfUseUrl)
-            if (termsOfUseAgree != null) envVars.put("DEVELOCITY_TERMS_OF_USE_AGREE", termsOfUseAgree)
             return envVars
         }
     }


### PR DESCRIPTION
All env vars are now prefixed with 'develocity-injection`:
- Env vars start with `DEVELOCITY_INJECTION_`
- Sys props start with `develocity-injection.`

This includes vars that used to be prefixed with 'gradle', such that `gradle.plugin-repository.url` -> `develocity-injection.plugin-repository.url`.

Some other property names were changed for consistency:
- `develocity.plugin-version` -> `develocity-injection.develocity-plugin-version`
- `develocity.build-scan.upload-in-background` -> `develocity-injection.upload-in-background`
- `develocity.auto-injection.custom-value` -> `develocity-injection.custom-value`

Input properties are documented in README.