### PR TITLE
Ensure input parameters are configuration cache inputs

### DIFF
--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -15,7 +15,10 @@ initscript {
     def getInputParam = { Gradle gradle, String name ->
         def ENV_VAR_PREFIX = ''
         def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-        return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
+        // We read the system property value always to make sure it becomes a configuration cache input
+        // Reading from gradle.startParameter.systemPropertiesArgs does not have that effect
+        def systemPropertyValue = System.getProperty(name)
+        return gradle.startParameter.systemPropertiesArgs[name] ?: systemPropertyValue ?: System.getenv(envVarName)
     }
 
     def requestedInitScriptName = getInputParam(gradle, 'develocity-injection.init-script-name')
@@ -83,7 +86,10 @@ initscript {
 static getInputParam(Gradle gradle, String name) {
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    return gradle.startParameter.systemPropertiesArgs[name] ?: System.getProperty(name) ?: System.getenv(envVarName)
+    // We read the system property value always to make sure it becomes a configuration cache input
+    // Reading from gradle.startParameter.systemPropertiesArgs does not have that effect
+    def systemPropertyValue = System.getProperty(name)
+    return gradle.startParameter.systemPropertiesArgs[name] ?: systemPropertyValue ?: System.getenv(envVarName)
 }
 
 def isTopLevelBuild = !gradle.parent

--- a/src/main/resources/develocity-injection.init.gradle
+++ b/src/main/resources/develocity-injection.init.gradle
@@ -15,10 +15,11 @@ initscript {
     def getInputParam = { Gradle gradle, String name ->
         def ENV_VAR_PREFIX = ''
         def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-        // We read the system property value always to make sure it becomes a configuration cache input
+        // We read the system property value first to make sure it becomes a configuration cache input
         // Reading from gradle.startParameter.systemPropertiesArgs does not have that effect
-        def systemPropertyValue = System.getProperty(name)
-        return gradle.startParameter.systemPropertiesArgs[name] ?: systemPropertyValue ?: System.getenv(envVarName)
+        // We read from gradle.startParameter since Gradle 7.0.2 and earlier cannot reliably read system properties
+        // using System.getProperty from init scripts.
+        return System.getProperty(name) ?: gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
     }
 
     def requestedInitScriptName = getInputParam(gradle, 'develocity-injection.init-script-name')
@@ -86,10 +87,11 @@ initscript {
 static getInputParam(Gradle gradle, String name) {
     def ENV_VAR_PREFIX = ''
     def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
-    // We read the system property value always to make sure it becomes a configuration cache input
+    // We read the system property value first to make sure it becomes a configuration cache input
     // Reading from gradle.startParameter.systemPropertiesArgs does not have that effect
-    def systemPropertyValue = System.getProperty(name)
-    return gradle.startParameter.systemPropertiesArgs[name] ?: systemPropertyValue ?: System.getenv(envVarName)
+    // We read from gradle.startParameter since Gradle 7.0.2 and earlier cannot reliably read system properties
+    // using System.getProperty from init scripts.
+    return System.getProperty(name) ?: gradle.startParameter.systemPropertiesArgs[name] ?: System.getenv(envVarName)
 }
 
 def isTopLevelBuild = !gradle.parent

--- a/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
+++ b/src/test/groovy/com/gradle/TestDevelocityInjection.groovy
@@ -487,4 +487,31 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         testGradle << CONFIGURATION_CACHE_GRADLE_VERSIONS
     }
 
+    @Requires({data.testGradle.compatibleWithCurrentJvm})
+    def "init script picks up system property changes when using configuration cache"() {
+        when:
+        def config = testConfig()
+        def result = run(testGradle, config, ["help", "--configuration-cache", "-Ddevelocity-injection.ccud-plugin.version=${CCUD_PLUGIN_VERSION}".toString()])
+
+        then:
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
+        outputContainsCcudPluginApplicationViaInitScript(result)
+
+        and:
+        outputContainsBuildScanUrl(result)
+
+        when:
+        result = run(testGradle, config, ["help", "--configuration-cache"])
+
+        then:
+        outputContainsDevelocityPluginApplicationViaInitScript(result, testGradle.gradleVersion)
+        outputMissesCcudPluginApplicationViaInitScript(result)
+
+        and:
+        outputContainsBuildScanUrl(result)
+
+        where:
+        testGradle << CONFIGURATION_CACHE_GRADLE_VERSIONS
+    }
+
 }


### PR DESCRIPTION
Reading from `gradle.startParameter.systemPropertiesArgs` does not add the system property as a configuration input for the configuration cache. When using the injection plugin together with configuration cache, that might cause configuration cache hits even though the injection parameters changed.