### PR TITLE
Adapt tests to future new Build Scan publication message

### DIFF
--- a/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
+++ b/src/test/groovy/com/gradle/BaseInitScriptTest.groovy
@@ -67,7 +67,7 @@ abstract class BaseInitScriptTest extends Specification {
         dvPlugin(BUILD_SCAN, '1.16'),
         dvPlugin(BUILD_SCAN, '1.10'),
     ]
-    static final BUILD_SCAN_MESSAGES = ["Publishing build scan...", "Publishing Build Scan..."]
+    static final BUILD_SCAN_MESSAGES = ["Publishing build scan...", "Publishing Build Scan...", "Publishing Build Scan to Develocity..."]
 
     // Gradle + plugin versions to test DV injection: used to test with project with no DV plugin defined
     static def getVersionsToTestForPluginInjection(List<TestGradleVersion> gradleVersions = ALL_GRADLE_VERSIONS) {


### PR DESCRIPTION
Similar to https://github.com/gradle/develocity-ci-injection/pull/52, a new Build Scan publication message will be introduced in the next Develocity Gradle plugin. This PR just adapts the test.